### PR TITLE
Add autocomplete to allow 1Pass to fill field

### DIFF
--- a/src/auth.py
+++ b/src/auth.py
@@ -15,13 +15,13 @@ def check_password():
     if "password_correct" not in st.session_state:
         # First run, show input for password.
         st.text_input(
-            "Password", type="password", on_change=password_entered, key="password"
+            "Password", type="password", on_change=password_entered, key="password", autocomplete="current-password"
         )
         return False
     elif not st.session_state["password_correct"]:
         # Password not correct, show input + error.
         st.text_input(
-            "Password", type="password", on_change=password_entered, key="password"
+            "Password", type="password", on_change=password_entered, key="password", autocomplete="current-password"
         )
         st.error("😕 Password incorrect")
         return False


### PR DESCRIPTION
# Pull Request

## Description

Currently defaults to `new-password` which suggests creating a password through 1Password etc.

## How Has This Been Tested?

It has not, and may fail linting, who knows

- [ ] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
