### PR TITLE
add line for Daily Latest MAE all GSPs to fig6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 altair==4.2.2
-nowcasting_datamodel==1.3.21
+nowcasting_datamodel==1.4.14
 numpy==1.24.1
 pandas==1.5.2
 plotly==5.10.0

--- a/src/forecast.py
+++ b/src/forecast.py
@@ -17,8 +17,8 @@ colour_per_model = {
     "cnn": "#FFD053",
     "National_xg": "#7BCDF3",
     "pvnet_v2": "#4c9a8e",
-    "PVLive Initial estimate": "#e4e4e4",
-    "PVLive Updated estimate": "#e4e4e4",
+    "PVLive Initial Estimate": "#e4e4e4",
+    "PVLive Updated Estimate": "#e4e4e4",
     "PVLive GSP Sum Estimate": "#FF9736",
     "PVLive GSP Sum Updated": "#FF9736",
 }

--- a/src/main.py
+++ b/src/main.py
@@ -187,7 +187,7 @@ def metric_page():
         df_mae,
         x="datetime_utc",
         y="MAE",
-        title="Nowcasting MAE",
+        title="Quartz Solar MAE",
         hover_data=["MAE", "datetime_utc"],
         color_discrete_sequence=["#FFAC5F"],
     )
@@ -209,7 +209,7 @@ def metric_page():
     # MAE by forecast horizon adding go.Figure
     fig2 = go.Figure(
         layout=go.Layout(
-            title=go.layout.Title(text="Nowcasting MAE by Forecast Horizon (selected in sidebar)"),
+            title=go.layout.Title(text="Quartz Solar MAE by Forecast Horizon (selected in sidebar)"),
             xaxis=go.layout.XAxis(title=go.layout.xaxis.Title(text="Date")),
             yaxis=go.layout.YAxis(title=go.layout.yaxis.Title(text="MAE (MW)")),
             legend=go.layout.Legend(title=go.layout.legend.Title(text="Chart Legend")),
@@ -271,7 +271,7 @@ def metric_page():
     fig4 = go.Figure(
         layout=go.Layout(
             title=go.layout.Title(
-                text="Nowcasting MAE by Forecast Horizon for Date Range(selected in sidebar)"
+                text="Quartz Solar MAE by Forecast Horizon for Date Range(selected in sidebar)"
             ),
             xaxis=go.layout.XAxis(title=go.layout.xaxis.Title(text="MAE (MW)")),
             yaxis=go.layout.YAxis(title=go.layout.yaxis.Title(text="Forecast Horizon (minutes)")),
@@ -313,7 +313,7 @@ def metric_page():
     # add chart with forecast horizons on x-axis and line for each day in the date range
     fig5 = go.Figure(
         layout=go.Layout(
-            title=go.layout.Title(text="Nowcasting MAE Forecast Horizon Values by Date"),
+            title=go.layout.Title(text="Quartz Solar MAE Forecast Horizon Values by Date"),
             xaxis=go.layout.XAxis(title=go.layout.xaxis.Title(text="Forecast Horizon (minutes)")),
             yaxis=go.layout.YAxis(title=go.layout.yaxis.Title(text="MAE (MW)")),
             legend=go.layout.Legend(title=go.layout.legend.Title(text="Date")),
@@ -375,7 +375,7 @@ def metric_page():
     # comparing MAE and RMSE
     fig6 = go.Figure(
         layout=go.Layout(
-            title=go.layout.Title(text="Nowcasting MAE with RMSE for Comparison"),
+            title=go.layout.Title(text="Quartz Solar MAE with RMSE for Comparison"),
             xaxis=go.layout.XAxis(title=go.layout.xaxis.Title(text="Date")),
             yaxis=go.layout.YAxis(title=go.layout.yaxis.Title(text="Error Value (MW)")),
             legend=go.layout.Legend(title=go.layout.legend.Title(text="Chart Legend")),

--- a/src/main.py
+++ b/src/main.py
@@ -117,9 +117,9 @@ def metric_page():
         metric_values_mae_gsp_sum = get_metric_value(
             session=session,
             name=name_mae_gsp_sum,
-            gsp_id=0,
             start_datetime_utc=starttime,
             end_datetime_utc=endtime,
+            # gsp_id=0,
             model_name=model_name,
         )
 

--- a/src/main.py
+++ b/src/main.py
@@ -119,7 +119,6 @@ def metric_page():
             name=name_mae_gsp_sum,
             start_datetime_utc=starttime,
             end_datetime_utc=endtime,
-            # gsp_id=0,
             model_name=model_name,
         )
 

--- a/src/main.py
+++ b/src/main.py
@@ -400,30 +400,32 @@ def metric_page():
             ),
         ]
     )
-    
-    fig6.update_layout(yaxis_range=[0, MAE_LIMIT_DEFAULT])
-    st.plotly_chart(fig6, theme="streamlit")
 
+    fig6.update_layout(yaxis_range=[0, MAE_LIMIT_DEFAULT])
+    
     fig7 = go.Figure(
         layout=go.Layout(
-            title=go.layout.Title(text="Daily Latest MAE All GSPs"),
-            xaxis=go.layout.XAxis(title=go.layout.xaxis.Title(text="Date")),
-            yaxis=go.layout.YAxis(title=go.layout.yaxis.Title(text="Error Value (MW)")),
-            legend=go.layout.Legend(title=go.layout.legend.Title(text="Chart Legend")),
+        title=go.layout.Title(text="Daily Latest MAE All GSPs"),
+        xaxis=go.layout.XAxis(title=go.layout.xaxis.Title(text="Date")),
+        yaxis=go.layout.YAxis(title=go.layout.yaxis.Title(text="Error Value (MW)")),
+        legend=go.layout.Legend(title=go.layout.legend.Title(text="Chart Legend")),
         )
     )
 
     fig7.add_traces(
         go.Scatter(
-                x=df_mae_all_gsp["datetime_utc"],
-                y=df_mae_all_gsp["MAE All GSPs"],
-                mode="lines",
-                name="Daily Latest MAE All GSPs",
-                line=dict(color=line_color[4]),
-            ),
-    )
+            x=df_mae_all_gsp["datetime_utc"],
+            y=df_mae_all_gsp["MAE All GSPs"],
+            mode="lines",
+            name="Daily Latest MAE All GSPs",
+            line=dict(color=line_color[4]),
+        ),
+        )
     
-    st.plotly_chart(fig7, theme="streamlit")
+    if model_name in ["pvnet_v2", "cnn"]:
+        
+        st.plotly_chart(fig6, theme="streamlit")
+        st.plotly_chart(fig7, theme="streamlit")
 
     st.subheader("Data - forecast horizon averaged")
     # get average MAE for each forecast horizon

--- a/src/main.py
+++ b/src/main.py
@@ -402,6 +402,7 @@ def metric_page():
     )
 
     fig6.update_layout(yaxis_range=[0, MAE_LIMIT_DEFAULT])
+    st.plotly_chart(fig6, theme="streamlit")
     
     fig7 = go.Figure(
         layout=go.Layout(
@@ -424,7 +425,6 @@ def metric_page():
     
     if model_name in ["pvnet_v2", "cnn"]:
         
-        st.plotly_chart(fig6, theme="streamlit")
         st.plotly_chart(fig7, theme="streamlit")
 
     st.subheader("Data - forecast horizon averaged")

--- a/src/main.py
+++ b/src/main.py
@@ -398,18 +398,32 @@ def metric_page():
                 mode="lines",
                 line=dict(color=line_color[0]),
             ),
-            go.Scatter(
-                x=df_mae_all_gsp["datetime_utc"],
-                y=df_mae_all_gsp["MAE All GSPs"],
-                mode="lines",
-                name="Daily Latest MAE All GSPs",
-                line=dict(color="#FFD053"),
-            ),
         ]
     )
     
     fig6.update_layout(yaxis_range=[0, MAE_LIMIT_DEFAULT])
     st.plotly_chart(fig6, theme="streamlit")
+
+    fig7 = go.Figure(
+        layout=go.Layout(
+            title=go.layout.Title(text="Daily Latest MAE All GSPs"),
+            xaxis=go.layout.XAxis(title=go.layout.xaxis.Title(text="Date")),
+            yaxis=go.layout.YAxis(title=go.layout.yaxis.Title(text="Error Value (MW)")),
+            legend=go.layout.Legend(title=go.layout.legend.Title(text="Chart Legend")),
+        )
+    )
+
+    fig7.add_traces(
+        go.Scatter(
+                x=df_mae_all_gsp["datetime_utc"],
+                y=df_mae_all_gsp["MAE All GSPs"],
+                mode="lines",
+                name="Daily Latest MAE All GSPs",
+                line=dict(color=line_color[4]),
+            ),
+    )
+    
+    st.plotly_chart(fig7, theme="streamlit")
 
     st.subheader("Data - forecast horizon averaged")
     # get average MAE for each forecast horizon


### PR DESCRIPTION
# Pull Request

## Description

This adds code to `main.py`, the `metric page`, to display `Daily Lates MAE All GSPs`. 
Currently the data frame I created for displaying `Daily Latest MAE All GSPs` returns an empty array, so I'd be curious to have answers to the following: 
- how best to query the database in cases like this to see if there is the data for `Daily Latest MAE All GSPs`
-  why the data frame I've added on `line 180` of `main.py`, `df_mae_all_gsp`, is empty

I tried the following in the pgAdmin database to see if the data's there:
`select * from metric_value 
where created_utc >='2023-06-28'
and metric_id = 2`
and did see values in the `value` column: 
<img width="174" alt="Screenshot 2023-07-05 at 14 47 52" src="https://github.com/openclimatefix/uk-analysis-dashboard/assets/86949265/70288266-2afe-44fd-bdde-7537d5dccfcd">

Theoretically the new line would be in the following graph, `fig6` in `main.py`:

<img width="847" alt="Screenshot 2023-07-05 at 14 45 31" src="https://github.com/openclimatefix/uk-analysis-dashboard/assets/86949265/0440acca-a56f-4b06-b9e0-a6b406477335">

Fixes #29

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
