### PR TITLE
Issue/55 get sites details

### DIFF
--- a/src/get_data.py
+++ b/src/get_data.py
@@ -15,7 +15,7 @@ from sqlalchemy.sql.expression import func
 from nowcasting_datamodel.models.gsp import LocationSQL, GSPYieldSQL, GSPYield
 from nowcasting_datamodel.models import MLModelSQL
 from nowcasting_datamodel.models.metric import DatetimeIntervalSQL, MetricSQL, MetricValueSQL
-from pvsite_datamodel.sqlmodels import UserSQL, SiteGroupSQL
+from pvsite_datamodel.sqlmodels import UserSQL, SiteGroupSQL, SiteSQL
 from pvsite_datamodel.read import get_site_group_by_name
 
 logger = logging.getLogger(__name__)
@@ -126,3 +126,13 @@ def update_user_site_group(session: Session, email: str, site_group_name: str) -
     site_group = get_site_group_by_name(session=session, site_group_name=site_group_name)
     user.site_group_uuid = site_group.site_group_uuid
     session.commit()
+
+def get_site_by_client_site_id(session: Session, client_site_id: str) -> List[SiteSQL]:
+    """Get site by client site id.
+    :param session: database session
+    :param client_site_id: client site id
+    """
+    query = session.query(SiteSQL)
+    query = query.filter(SiteSQL.client_site_id == client_site_id)
+    site = query.one_or_none()
+    return site

--- a/src/sites_toolbox.py
+++ b/src/sites_toolbox.py
@@ -31,10 +31,9 @@ def get_user_details(session, email):
     return user_sites, user_site_group, user_site_count
 
 # get details for one site
-
-def get_site_details(session, site_selection):
+def get_site_details(session, site_uuid):
   """Get the site details for one site"""
-  site = get_site_by_uuid(session=session, site_uuid=site_selection)
+  site = get_site_by_uuid(session=session, site_uuid=site_uuid)
   site_details = {"site_uuid": str(site.site_uuid), 
                   "client_site_id": str(site.client_site_id),
                   "client_site_name": str(site.client_site_name),
@@ -50,7 +49,6 @@ def get_site_details(session, site_selection):
   return site_details
 
 # user selects site by site_uuid or client_site_id
-
 def select_site_id(dbsession, query_method):
         if query_method == "site_uuid":
             site_uuids = [str(site.site_uuid) for site in get_all_sites(session=dbsession)]
@@ -61,8 +59,7 @@ def select_site_id(dbsession, query_method):
             site = get_site_by_client_site_id(session=dbsession, client_site_id = client_site_id)
             selected_uuid = str(site.site_uuid)
         elif query_method not in ["site_uuid", "client_site_id"]:
-            raise ValueError ("Please select a valid query_method")
-           
+            raise ValueError("Please select a valid query_method.")
         return selected_uuid
 
 
@@ -121,7 +118,7 @@ def sites_toolbox_page():
     site_id = select_site_id(dbsession=session, query_method=query_method)
 
     if st.button("Get site details"):
-        site_details = get_site_details(session=session, site_selection=site_id)
+        site_details = get_site_details(session=session, site_uuid=site_id)
         site_id = site_details["client_site_id"] if query_method == "client_site_id" else site_details["site_uuid"]
         st.write("Here are the site details for site", site_id, ":", site_details)
         if st.button("Close site details"):

--- a/src/sites_toolbox.py
+++ b/src/sites_toolbox.py
@@ -34,31 +34,36 @@ def get_user_details(session, email):
 
 def get_site_details(session, site_selection):
   """Get the site details for one site"""
-  site_uuid = get_site_by_uuid(session=session, site_uuid=site_selection)
-  site_details = {"site_uuid": str(site_uuid.site_uuid), 
-                  "client_site_id": str(site_uuid.client_site_id),
-                  "client_site_name": str(site_uuid.client_site_name),
-                  "site_group_name": str(site_uuid.site_groups[0].site_group_name),
-                  "latitude": str(site_uuid.latitude),
-                  "longitude": str(site_uuid.longitude),
-                  "DNO": str(site_uuid.dno),
-                  "GSP": str(site_uuid.gsp),
-                  "tilt": str(site_uuid.tilt),
-                  "orientation": str(site_uuid.orientation),
-                  "capacity": (f'{site_uuid.capacity_kw} kw'),
-                  "date_added": (site_uuid.created_utc.strftime("%Y-%m-%d"))}
+  site = get_site_by_uuid(session=session, site_uuid=site_selection)
+  site_details = {"site_uuid": str(site.site_uuid), 
+                  "client_site_id": str(site.client_site_id),
+                  "client_site_name": str(site.client_site_name),
+                  "site_group_names" : [site_group.site_group_name for site_group in site.site_groups],
+                  "latitude": str(site.latitude),
+                  "longitude": str(site.longitude),
+                  "DNO": str(site.dno),
+                  "GSP": str(site.gsp),
+                  "tilt": str(site.tilt),
+                  "orientation": str(site.orientation),
+                  "capacity": (f'{site.capacity_kw} kw'),
+                  "date_added": (site.created_utc.strftime("%Y-%m-%d"))}
   return site_details
+
+# user selects site by site_uuid or client_site_id
 
 def select_site_id(dbsession, query_method):
         if query_method == "site_uuid":
-            site_list = [str(site.site_uuid) for site in get_all_sites(session=dbsession)]
-            selected_id = st.selectbox("Sites by site_uuid", site_list)
+            site_uuids = [str(site.site_uuid) for site in get_all_sites(session=dbsession)]
+            selected_uuid = st.selectbox("Sites by site_uuid", site_uuids)
         elif query_method == "client_site_id":
-            site_list= [str(site.client_site_id) for site in get_all_sites(session=dbsession)]
-            selected_id = st.selectbox("Sites by client_site_id", site_list)
-            selected_id = get_site_by_client_site_id(session=dbsession, client_site_id = selected_id)
-            selected_id = str(selected_id.site_uuid)
-        return selected_id
+            client_site_ids= [str(site.client_site_id) for site in get_all_sites(session=dbsession)]
+            client_site_id= st.selectbox("Sites by client_site_id", client_site_ids)
+            site = get_site_by_client_site_id(session=dbsession, client_site_id = client_site_id)
+            selected_uuid = str(site.site_uuid)
+        elif query_method not in ["site_uuid", "client_site_id"]:
+            raise ValueError ("Please select a valid query_method")
+           
+        return selected_uuid
 
 
 def sites_toolbox_page():

--- a/src/sites_toolbox.py
+++ b/src/sites_toolbox.py
@@ -1,22 +1,24 @@
 """This module contains the sites toolbox for the OCF dashboard"""
 import os
 import streamlit as st
-from datetime import datetime, timedelta, time, timezone
+from datetime import datetime as dt, timedelta, time, timezone
 from pvsite_datamodel.connection import DatabaseConnection
 from pvsite_datamodel.read import (
     get_all_sites,
     get_user_by_email,
+    get_site_by_uuid,
 )
 from get_data import (
     get_all_users,
     get_all_site_groups,
+    get_site_by_client_site_id,    
     update_user_site_group,
 )
 
 
 import plotly.graph_objects as go
 
-
+# get details for one user 
 def get_user_details(session, email):
     """Get the user details from the database"""
     user_details = get_user_by_email(session=session, email=email)
@@ -27,6 +29,36 @@ def get_user_details(session, email):
         for site in user_details.site_group.sites
     ]
     return user_sites, user_site_group, user_site_count
+
+# get details for one site
+
+def get_site_details(session, site_selection):
+  """Get the site details for one site"""
+  site_uuid = get_site_by_uuid(session=session, site_uuid=site_selection)
+  site_details = {"site_uuid": str(site_uuid.site_uuid), 
+                  "client_site_id": str(site_uuid.client_site_id),
+                  "client_site_name": str(site_uuid.client_site_name),
+                  "site_group_name": str(site_uuid.site_groups[0].site_group_name),
+                  "latitude": str(site_uuid.latitude),
+                  "longitude": str(site_uuid.longitude),
+                  "DNO": str(site_uuid.dno),
+                  "GSP": str(site_uuid.gsp),
+                  "tilt": str(site_uuid.tilt),
+                  "orientation": str(site_uuid.orientation),
+                  "capacity": (f'{site_uuid.capacity_kw} kw'),
+                  "date_added": (site_uuid.created_utc.strftime("%Y-%m-%d"))}
+  return site_details
+
+def select_site_id(dbsession, query_method):
+        if query_method == "site_uuid":
+            site_list = [str(site.site_uuid) for site in get_all_sites(session=dbsession)]
+            selected_id = st.selectbox("Sites by site_uuid", site_list)
+        elif query_method == "client_site_id":
+            site_list= [str(site.client_site_id) for site in get_all_sites(session=dbsession)]
+            selected_id = st.selectbox("Sites by client_site_id", site_list)
+            selected_id = get_site_by_client_site_id(session=dbsession, client_site_id = selected_id)
+            selected_id = str(selected_id.site_uuid)
+        return selected_id
 
 
 def sites_toolbox_page():
@@ -49,17 +81,14 @@ def sites_toolbox_page():
         # get the user details
         users = get_all_users(session=session)
         user_list = [user.email for user in users]
-        sites = get_all_sites(session=session)
-        # site_uuids = [str(site.site_uuid) for site in sites]
-        site_groups = get_all_site_groups(session=session)
-        # site_group_name = [site_groups.site_group_name for site_groups in site_groups]
+      
 
     st.markdown(
         f'<h1 style="color:#63BCAF;font-size:32px;">{"Get User Details"}</h1>',
         unsafe_allow_html=True,
     )
     email = st.selectbox("Enter email of user you want to know about.", user_list)
-
+    # getting user details 
     if st.button("Get user details"):
         user_sites, user_site_group, user_site_count = get_user_details(
             session=session, email=email
@@ -76,3 +105,20 @@ def sites_toolbox_page():
         )
         if st.button("Close user details"):
             st.empty()
+            
+    # getting site details   
+    st.markdown(
+        f'<h1 style="color:#63BCAF;font-size:32px;">{"Get Site Details"}</h1>',
+        unsafe_allow_html=True,
+    )
+    query_method = st.radio("Select site by", ("site_uuid", "client_site_id"))
+    
+    site_id = select_site_id(dbsession=session, query_method=query_method)
+
+    if st.button("Get site details"):
+        site_details = get_site_details(session=session, site_selection=site_id)
+        site_id = site_details["client_site_id"] if query_method == "client_site_id" else site_details["site_uuid"]
+        st.write("Here are the site details for site", site_id, ":", site_details)
+        if st.button("Close site details"):
+            st.empty()
+    

--- a/tests/test_sites_toolbox.py
+++ b/tests/test_sites_toolbox.py
@@ -23,7 +23,7 @@ def test_get_site_details(db_session):
   """Test the get site details function"""
   site = make_site(db_session=db_session, ml_id=1)
 
-  site_details = get_site_details(session=db_session, site_selection=str(site.site_uuid))
+  site_details = get_site_details(session=db_session, site_uuid=str(site.site_uuid))
 
   assert site_details == {"site_uuid": str(site.site_uuid),
                           "client_site_id": str(site.client_site_id),

--- a/tests/test_sites_toolbox.py
+++ b/tests/test_sites_toolbox.py
@@ -28,7 +28,7 @@ def test_get_site_details(db_session):
   assert site_details == {"site_uuid": str(site.site_uuid),
                           "client_site_id": str(site.client_site_id),
                           "client_site_name": str(site.client_site_name),
-                          "site_group_name": str(site.site_groups[0].site_group_name),
+                          "site_group_names": [site_group.site_group_name for site_group in site.site_groups],
                           "latitude": str(site.latitude),
                           "longitude": str(site.longitude),
                           "DNO": str(site.dno),
@@ -44,9 +44,9 @@ def test_select_site_id(db_session):
   """Test the select site id function"""
   site = make_site(db_session=db_session, ml_id=1)
  
-  selected_id = select_site_id(dbsession=db_session, query_method="site_uuid")
+  site_uuid= select_site_id(dbsession=db_session, query_method="site_uuid")
 
-  assert selected_id == str(site.site_uuid)
+  assert site_uuid == str(site.site_uuid)
 
-  selected_id = select_site_id(dbsession=db_session, query_method="client_site_id")
-  assert selected_id == str(site.site_uuid)
+  site_uuid = select_site_id(dbsession=db_session, query_method="client_site_id")
+  assert site_uuid == str(site.site_uuid)

--- a/tests/test_sites_toolbox.py
+++ b/tests/test_sites_toolbox.py
@@ -1,5 +1,5 @@
 """Test the toolbox functions"""
-from sites_toolbox import get_user_details
+from sites_toolbox import get_user_details, get_site_details, select_site_id
 from pvsite_datamodel.write.user_and_site import make_site, make_site_group, make_user
 
 def test_get_user_details(db_session):
@@ -17,3 +17,36 @@ def test_get_user_details(db_session):
   assert user_sites == [{"site_uuid": str(site.site_uuid), "client_site_id": str(site.client_site_id)}for site in user.site_group.sites]
   assert user_site_group == "test_site_group"
   assert user_site_count == 2
+
+# test for get_site_details
+def test_get_site_details(db_session):
+  """Test the get site details function"""
+  site = make_site(db_session=db_session, ml_id=1)
+
+  site_details = get_site_details(session=db_session, site_selection=str(site.site_uuid))
+
+  assert site_details == {"site_uuid": str(site.site_uuid),
+                          "client_site_id": str(site.client_site_id),
+                          "client_site_name": str(site.client_site_name),
+                          "site_group_name": str(site.site_groups[0].site_group_name),
+                          "latitude": str(site.latitude),
+                          "longitude": str(site.longitude),
+                          "DNO": str(site.dno),
+                          "GSP": str(site.gsp),
+                          "tilt": str(site.tilt),
+                          "orientation": str(site.orientation),
+                          "capacity": (f'{site.capacity_kw} kw'),
+                          "date_added": (site.created_utc.strftime("%Y-%m-%d"))}
+
+
+# test for select_site_id
+def test_select_site_id(db_session):
+  """Test the select site id function"""
+  site = make_site(db_session=db_session, ml_id=1)
+ 
+  selected_id = select_site_id(dbsession=db_session, query_method="site_uuid")
+
+  assert selected_id == str(site.site_uuid)
+
+  selected_id = select_site_id(dbsession=db_session, query_method="client_site_id")
+  assert selected_id == str(site.site_uuid)


### PR DESCRIPTION
# Pull Request

## Description
This PR adds the feature and tests for getting details for one site, showing metadata. 

![Screenshot 2023-09-12 at 16 44 38](https://github.com/openclimatefix/uk-analysis-dashboard/assets/86949265/3c57367b-0aa2-4d85-9eb9-7bedb26d7874)

This is what the metadata looks like. I could use a little help extracting the names from the weird dictionary thing for `DNO`, `GSP`, and `Region`(still needs to be added). And looking at it now, some of the metadata could use formatting.: 

![Screenshot 2023-09-12 at 16 45 19](https://github.com/openclimatefix/uk-analysis-dashboard/assets/86949265/e288ed16-f8a8-4084-bc0d-982c383efc85)

I have added the option for selecting a site by `client_site_id` and added a function to `get_data.py` to `get_site_by_client_site_id` but need some help not getting an error when the `client_site_id` is not unique:

![Screenshot 2023-09-12 at 16 45 55](https://github.com/openclimatefix/uk-analysis-dashboard/assets/86949265/9a588d54-3a27-4810-9b3c-871bf27a0e62)

It'll be easy to add the `client_site_name` search option to the existing function, but for now, since most of the these names are `None`, I wasn't convinced there was much point in adding this option just yet. Maybe it could be added in cases of "not None". 

Fixes #55

## How Has This Been Tested?
Wrote pytests and ran the code locally. 
`test_get_site_details` is currently failing. When I removed `site_group_name` from the dictionary altogether, the test passed. I'm wondering how to get around this. 

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
