### PR TITLE
forecast updates

### DIFF
--- a/src/forecast.py
+++ b/src/forecast.py
@@ -275,7 +275,7 @@ def forecast_page():
             elif k == "PVLive GSP Sum Updated":
                 line = dict(color=colour_per_model[k])
 
-            fig.add_trace(go.Scatter(x=x, y=y, mode="lines", name=k, line=line))
+            fig.add_trace(go.Scatter(x=x, y=y, mode="lines", name=k, line=line, visible="legendonly"))
 
     fig.add_trace(
         go.Scatter(

--- a/src/forecast.py
+++ b/src/forecast.py
@@ -66,6 +66,7 @@ def forecast_page():
             forecast_models.remove("National_xg")
             st.sidebar.warning("National_xg only available for National forecast.")
 
+    show_prob = st.sidebar.checkbox('Show Probabilities', value=False)
     use_adjuster = st.sidebar.radio("Use adjuster", [True, False], index=1)
 
     forecast_type = st.sidebar.radio(
@@ -210,7 +211,7 @@ def forecast_page():
             )
         )
 
-    if model != "cnn" and len(forecast) > 0:
+    if model != "cnn" and len(forecast) > 0 and show_prob:
         try:
             properties_0 = forecast[0]._properties
             if isinstance(properties_0, dict):


### PR DESCRIPTION
# Pull Request

## Description

- by default turn off gsp sums
- add check box to turn on and off probablistic

Fixes #52 

![Screenshot 2023-09-26 at 08 12 06](https://github.com/openclimatefix/uk-analysis-dashboard/assets/34686298/9b293da3-cce6-48d2-aba3-ada758caea21)


## How Has This Been Tested?

ran locally

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
