### PR TITLE
Issue/create new site group

### DIFF
--- a/src/get_data.py
+++ b/src/get_data.py
@@ -309,16 +309,3 @@ def create_user(
     session.commit()
 
     return user
-
-
-# create a new site group
-def create_new_site_group(session: Session, site_group_name: str) -> SiteGroupSQL:
-    """Creating a new site group
-    :param session: database session
-    :param site_group_name: name of the site group this user will be part of"""
-
-    new_site_group = SiteGroupSQL(site_group_name=site_group_name)
-    session.add(new_site_group)
-    session.commit()
-
-    return new_site_group

--- a/src/get_data.py
+++ b/src/get_data.py
@@ -307,6 +307,18 @@ def create_user(
     session.add(user)
     site_group.users.append(user)
     session.commit()
-    print(user)
 
     return user
+
+
+# create a new site group
+def create_new_site_group(session: Session, site_group_name: str) -> SiteGroupSQL:
+    """Creating a new site group
+    :param session: database session
+    :param site_group_name: name of the site group this user will be part of"""
+
+    new_site_group = SiteGroupSQL(site_group_name=site_group_name)
+    session.add(new_site_group)
+    session.commit()
+
+    return new_site_group

--- a/src/sites_toolbox.py
+++ b/src/sites_toolbox.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone
 from sqlalchemy import func
 from pvsite_datamodel.connection import DatabaseConnection
 from pvsite_datamodel.sqlmodels import SiteSQL
-from pvsite_datamodel.write.user_and_site import make_user
+from pvsite_datamodel.write.user_and_site import make_site_group
 from pvsite_datamodel.read import (
     get_all_sites,
     get_user_by_email,
@@ -17,7 +17,6 @@ from pvsite_datamodel.read import (
 
 from get_data import (
     create_new_site,
-    create_new_site_group,
     create_user,
     get_all_users,
     get_all_site_groups,
@@ -479,8 +478,8 @@ def sites_toolbox_page():
                         unsafe_allow_html=True,
                     )
                 else:
-                    new_site_group = create_new_site_group(
-                        session=session,
+                    new_site_group = make_site_group(
+                        db_session=session,
                         site_group_name=new_site_group_name,
                     )
                     new_site_group_details = {

--- a/src/sites_toolbox.py
+++ b/src/sites_toolbox.py
@@ -17,6 +17,7 @@ from pvsite_datamodel.read import (
 
 from get_data import (
     create_new_site,
+    create_new_site_group,
     create_user,
     get_all_users,
     get_all_site_groups,
@@ -318,7 +319,7 @@ def sites_toolbox_page():
 
     # create a new site
     st.markdown(
-        f'<h1 style="color:#63BCAF;font-size:32px;">{"Create New Site"}</h1>',
+        f'<h1 style="color:#63BCAF;font-size:32px;">{"Create Site"}</h1>',
         unsafe_allow_html=True,
     )
     with st.expander("Input new site data"):
@@ -406,7 +407,7 @@ def sites_toolbox_page():
 
     # create a new user
     st.markdown(
-        f'<h1 style="color:#63BCAF;font-size:32px;">{"Create New User"}</h1>',
+        f'<h1 style="color:#63BCAF;font-size:32px;">{"Create User"}</h1>',
         unsafe_allow_html=True,
     )
 
@@ -419,7 +420,9 @@ def sites_toolbox_page():
                 unsafe_allow_html=True,
             )
             email = st.text_input("User Email")
-            site_group_name = st.selectbox("Select a group", site_groups, key="site_group")
+            site_group_name = st.selectbox(
+                "Select a group", site_groups, key="site_group"
+            )
             email_validation = validate_email(email)
             # check that site group exists
             if st.button(f"Create new user"):
@@ -434,7 +437,6 @@ def sites_toolbox_page():
                         unsafe_allow_html=True,
                     )
                 else:
-
                     user = create_user(
                         session=session,
                         email=email,
@@ -450,4 +452,43 @@ def sites_toolbox_page():
 
                 if st.button("Close details"):
                     st.empty()
-              
+
+    # create site group
+    st.markdown(
+        f'<h1 style="color:#63BCAF;font-size:32px;">{"Create Site Group"}</h1>',
+        unsafe_allow_html=True,
+    )
+
+    with st.expander("Input new group data"):
+        with connection.get_session() as session:
+            st.markdown(
+                f'<h1 style="color:#FFD053;font-size:22px;">{"Site Group Information"}</h1>',
+                unsafe_allow_html=True,
+            )
+            new_site_group_name = st.text_input("Enter new site group name")
+            # check that site group exists
+            if st.button(f"Create new site group"):
+                if new_site_group_name == "":
+                    st.markdown(
+                        f'<p style="color:#f07167;font-size:16px;">{"Please enter a valid name for the site group."}</p>',
+                        unsafe_allow_html=True,
+                    )
+                elif new_site_group_name in site_groups:
+                    st.markdown(
+                        f'<p style="color:#f07167;font-size:16px;">{"This site group already exists."}</p>',
+                        unsafe_allow_html=True,
+                    )
+                else:
+                    new_site_group = create_new_site_group(
+                        session=session,
+                        site_group_name=new_site_group_name,
+                    )
+                    new_site_group_details = {
+                        "site_group": str(new_site_group.site_group_name),
+                        "site_group_uuid": str(new_site_group.site_group_uuid),
+                        "date_added": (new_site_group.created_utc.strftime("%Y-%m-%d")),
+                    }
+                    st.json(new_site_group_details)
+
+                if st.button("Close details"):
+                    st.empty()

--- a/tests/test_get_data.py
+++ b/tests/test_get_data.py
@@ -3,7 +3,6 @@ from get_data import (
     add_site_to_site_group,
     create_new_site,
     create_user,
-    create_new_site_group,
     get_all_users,
     get_all_site_groups,
 )

--- a/tests/test_get_data.py
+++ b/tests/test_get_data.py
@@ -113,21 +113,3 @@ def test_create_user(db_session):
     assert user_1.site_group.site_group_name == "test_site_group"
     assert user_1.site_group_uuid == site_group_1.site_group_uuid
 
-
-# test to create a new site group
-def test_create_new_site_group(db_session):
-    """Test to creat a new site group."""
-
-    site_1 = make_site(db_session=db_session, ml_id=1)
-    site_2 = make_site(db_session=db_session, ml_id=2)
-    site_3 = make_site(db_session=db_session, ml_id=3)
-
-    new_site_group = create_new_site_group(
-        session=db_session, site_group_name="new_site_group"
-    )
-    new_site_group.sites.append(site_1)
-    new_site_group.sites.append(site_2)
-    new_site_group.sites.append(site_3)
-
-    assert new_site_group.site_group_name == "new_site_group"
-    assert len(new_site_group.sites) == 3

--- a/tests/test_get_data.py
+++ b/tests/test_get_data.py
@@ -3,6 +3,7 @@ from get_data import (
     add_site_to_site_group,
     create_new_site,
     create_user,
+    create_new_site_group,
     get_all_users,
     get_all_site_groups,
 )
@@ -111,3 +112,22 @@ def test_create_user(db_session):
     assert user_1.email == "test_user@test.org"
     assert user_1.site_group.site_group_name == "test_site_group"
     assert user_1.site_group_uuid == site_group_1.site_group_uuid
+
+
+# test to create a new site group
+def test_create_new_site_group(db_session):
+    """Test to creat a new site group."""
+
+    site_1 = make_site(db_session=db_session, ml_id=1)
+    site_2 = make_site(db_session=db_session, ml_id=2)
+    site_3 = make_site(db_session=db_session, ml_id=3)
+
+    new_site_group = create_new_site_group(
+        session=db_session, site_group_name="new_site_group"
+    )
+    new_site_group.sites.append(site_1)
+    new_site_group.sites.append(site_2)
+    new_site_group.sites.append(site_3)
+
+    assert new_site_group.site_group_name == "new_site_group"
+    assert len(new_site_group.sites) == 3


### PR DESCRIPTION
# Pull Request

## Description
Add section to OCF Dashboard to create a new user group.

An error message is given if the site group name is left blank or if the group already exists. 

<img width="904" alt="Screenshot 2023-10-12 at 17 56 57" src="https://github.com/openclimatefix/uk-analysis-dashboard/assets/86949265/9c55e119-603a-4cd7-b3fb-c0fe60b4ef39">

<img width="857" alt="Screenshot 2023-10-12 at 17 58 11" src="https://github.com/openclimatefix/uk-analysis-dashboard/assets/86949265/4a68abc3-ef4a-47dd-967b-b79b57e70902">

Once a new group is made, it shows some basic site group information. This could be changed. 

<img width="824" alt="Screenshot 2023-10-12 at 17 59 35" src="https://github.com/openclimatefix/uk-analysis-dashboard/assets/86949265/fb3dea2d-a052-4df5-8244-26047757355e">

## How Has This Been Tested?

Wrote a test for function that creates a new site group
Ran the code locally

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
