### PR TITLE
add options of forecast page

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 altair==4.2.2
 nowcasting_datamodel==1.5.32
-pvsite-datamodel==1.0.7
+pvsite-datamodel==1.0.14
 numpy==1.24.1
 pandas==1.5.3
 plotly==5.10.0


### PR DESCRIPTION
# Pull Request

## Description

add filter on side of site forecast page
![Screenshot 2024-03-12 at 14 34 54](https://github.com/openclimatefix/uk-analysis-dashboard/assets/34686298/50674c28-9812-4ba2-9af8-0fbbbef5a0fd)

## How Has This Been Tested?

Tested it locally
- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
