### PR TITLE
add more init times

### DIFF
--- a/src/forecast.py
+++ b/src/forecast.py
@@ -71,12 +71,13 @@ def forecast_page():
 
             d = st.sidebar.date_input("Forecast creation date:", now.date())
             dd = datetime.combine(d, time(0, 0))
-            initial_times = [dd + timedelta(minutes=30 * i) for i in range(48)]
+            initial_times = [dd - timedelta(days=1) + timedelta(hours=3 * i) for i in range(8)]
+            initial_times += [dd + timedelta(minutes=30 * i) for i in range(48)]
 
             select_init_times = st.sidebar.multiselect(
                 "Forecast creation time",
                 initial_times,
-                [initial_times[x] for x in [6, 12, 18, 24, 30]],
+                [initial_times[x] for x in [14, 20, 26, 32, 38]],
             )
             select_init_times = sorted(select_init_times)
             forecast_time = select_init_times[0]

--- a/src/forecast.py
+++ b/src/forecast.py
@@ -77,7 +77,7 @@ def forecast_page():
             select_init_times = st.sidebar.multiselect(
                 "Forecast creation time",
                 initial_times,
-                [initial_times[x] for x in [14, 20, 26, 32, 38]],
+                [initial_times[x] for x in [2,6, 14, 20, 26, 32, 38]],
             )
             select_init_times = sorted(select_init_times)
             forecast_time = select_init_times[0]


### PR DESCRIPTION
# Pull Request

## Description

- add more init times on forecast

<img width="1391" alt="Screenshot 2024-03-14 at 08 50 02" src="https://github.com/openclimatefix/uk-analysis-dashboard/assets/34686298/12fa68ce-eea6-44ed-9a32-0b9ccd585cd6">

## How Has This Been Tested?

tested locally

- [x] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
