### PR TITLE
add option to see sites database api requests.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 altair==4.2.2
 nowcasting_datamodel==1.5.39
-pvsite-datamodel==1.0.21
+pvsite-datamodel==1.0.22
 numpy==1.24.1
 pandas==1.5.3
 plotly==5.10.0


### PR DESCRIPTION
# Pull Request

## Description

#143 

Add optiont to view sites API requests. This will work for India too

<img width="718" alt="Screenshot 2024-04-26 at 10 28 18" src="https://github.com/openclimatefix/uk-analysis-dashboard/assets/34686298/610291a3-f100-4ab1-8ce9-6572f08c0e8c">
The user can select which database they want to look at

Fixes #

## How Has This Been Tested?

Ran it locally

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
