### PR TITLE
add adjuster page

### DIFF
--- a/src/adjuster.py
+++ b/src/adjuster.py
@@ -18,6 +18,9 @@ def adjuster_page():
         unsafe_allow_html=True,
     )
 
+    url = 'https://www.notion.so/openclimatefix/Adjuster-cae707fbac0a440895f8aacec2a7b55c?pvs=4'
+    st.markdown(f'<a href="{url}" target="_blank">Link to Notion page</a>', unsafe_allow_html=True)
+
     connection = DatabaseConnection(url=os.environ["DB_URL"], echo=True)
     with connection.get_session() as session:
         # get all the models with adjust values

--- a/src/adjuster.py
+++ b/src/adjuster.py
@@ -1,0 +1,77 @@
+""" This page shows the current adjuster values """
+import os
+import pandas as pd
+
+import plotly.graph_objects as go
+
+from nowcasting_datamodel.read.read_metric import read_latest_me_national
+from nowcasting_datamodel.connection import DatabaseConnection
+from nowcasting_datamodel.models import MetricValueSQL, MetricSQL, MLModelSQL
+import streamlit as st
+
+
+def adjuster_page():
+    """Main page for status"""
+
+    st.markdown(
+        f'<h1 style="color:#63BCAF;font-size:48px;">{"Adjuster"}</h1>',
+        unsafe_allow_html=True,
+    )
+
+    connection = DatabaseConnection(url=os.environ["DB_URL"], echo=True)
+    with connection.get_session() as session:
+        # get all the models with adjust values
+        model_names = get_model_names_with_adjuster_values(session)
+
+        # Add dropdown to select GSP region
+        model_name = st.sidebar.selectbox("Select a models", model_names, index=0)
+
+        # get adjust values
+        metric_values = read_latest_me_national(
+            session=session,
+            model_name=model_name,
+        )
+
+        # format
+        metric_values = [
+            [metric_value.value, metric_value.time_of_day, metric_value.forecast_horizon_minutes]
+            for metric_value in metric_values
+        ]
+
+    metric_values_df = pd.DataFrame(
+        columns=["value", "time_of_day", "forecast_horizon_minutes"], data=metric_values
+    )
+
+    # pivot to make in 2d data ofr time_of_day vs forecast_horizon_minutes
+    metric_values_df = metric_values_df.pivot(
+        index="time_of_day", columns="forecast_horizon_minutes", values="value"
+    )
+
+    fig = go.Figure(
+        data=go.Heatmap(
+            z=metric_values_df.values, x=metric_values_df.columns, y=metric_values_df.index
+        ),
+        layout=go.Layout(
+            title=go.layout.Title(text=f"Adjuster Value for {model_name}"),
+            xaxis=go.layout.XAxis(title=go.layout.xaxis.Title(text="Forecast Horizon [minutes]")),
+            yaxis=go.layout.YAxis(title=go.layout.yaxis.Title(text="Time of day")),
+        ),
+    )
+
+    # add
+    st.plotly_chart(fig, theme="streamlit")
+
+
+def get_model_names_with_adjuster_values(session, metric_name: str = "Half Hourly ME"):
+    """Get model name with adjuster values"""
+    # start main query
+    query = session.query(MetricValueSQL)
+    query = query.join(MetricSQL)
+    query = query.join(MLModelSQL)
+    query = query.distinct(MLModelSQL.name)
+    # filter on metric name
+    query = query.filter(MetricSQL.name == metric_name)
+    # get all results
+    metric_values = query.all()
+    model_names = [metric_value.model.name for metric_value in metric_values]
+    return model_names

--- a/src/main.py
+++ b/src/main.py
@@ -32,6 +32,7 @@ from tables.summary import make_recent_summary_stats, make_forecast_horizon_tabl
 from users import user_page
 from nwp_page import nwp_page
 from satellite_page import satellite_page
+from adjuster import adjuster_page
 
 st.get_option("theme.primaryColor")
 st.set_page_config(layout="wide", page_title="OCF Dashboard")
@@ -282,6 +283,7 @@ if check_password():
         "API Users": user_page,
         "NWP": nwp_page,
         "Satellite": satellite_page,
+        "Adjuster": adjuster_page,
     }
 
     demo_name = st.sidebar.selectbox("Choose a page", page_names_to_funcs.keys())


### PR DESCRIPTION
# Pull Request

## Description

Add a page to display the adjuster values
<img width="1003" alt="Screenshot 2024-06-05 at 20 28 35" src="https://github.com/openclimatefix/uk-analysis-dashboard/assets/34686298/f25fb091-be4d-4f5e-b078-99681da29702">

## How Has This Been Tested?

Tried it locally and it works

- [x] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
