### PR TITLE
Make colours more consistent

### DIFF
--- a/src/forecast.py
+++ b/src/forecast.py
@@ -278,6 +278,7 @@ def plot_forecasts(fig, forecast_per_model, selected_prob_models, show_prob):
                 line=dict(color=get_colour_from_model_name(model)), 
                 opacity=opacity,
                 hovertemplate="<br>%{x}<br>" + "<b>%{y:.2f}</b>MW",
+                legendgroup=model,
             )
         )
 
@@ -297,9 +298,11 @@ def plot_forecasts(fig, forecast_per_model, selected_prob_models, show_prob):
                             mode="lines",
                             name="p10: " + model,
                             line=dict(color=get_colour_from_model_name(model), width=0),
+                            legendgroup=model,
                             showlegend=False,
                         )
                     )
+                    
                     fig.add_trace(
                         go.Scatter(
                             x=x,
@@ -308,9 +311,12 @@ def plot_forecasts(fig, forecast_per_model, selected_prob_models, show_prob):
                             name="p90: " + model,
                             line=dict(color=get_colour_from_model_name(model), width=0),
                             fill="tonexty",
+                            legendgroup=model,
                             showlegend=False,
                         )
                     )
+                    
+                    
             except Exception as e:
                 print(e)
                 print("Could not add plevel to chart")

--- a/src/plots/utils.py
+++ b/src/plots/utils.py
@@ -45,6 +45,7 @@ def get_colour_from_model_name(model_name, opacity=1.0):
             colour = colour_per_model[model_name_only]
         else:
             colour = next(line_color_cycle)
+            colour_per_model[model_name_only] = colour
     return colour
 
     # change opacity to hex


### PR DESCRIPTION
This pull request makes the colours of lines which are not explicitly given a colour (i.e. the extra models) more consistent in the app and this easier to analyse. Also adds a fix to make the uncertainty lines disappear when the central line is deselected in the key