### PR TITLE
Include all PVNet models in plot features

### DIFF
--- a/src/plots/utils.py
+++ b/src/plots/utils.py
@@ -80,7 +80,7 @@ def model_is_probabilistic(model_name):
     is_prob = (
         (model_name in ["National_xg", "blend"])
         or
-        (model_name.startswith("pvnet_v2") and not model_name.endswith("_gsp_sum"))
+        (model_name.startswith("pvnet") and not model_name.endswith("_gsp_sum"))
     )
     return is_prob
 
@@ -90,7 +90,7 @@ def model_is_gsp_regional(model_name):
     is_regional = (
         (model_name=="cnn")
         or
-        (model_name.startswith("pvnet_v2") and not model_name.endswith("_gsp_sum"))
+        (model_name.startswith("pvnet") and not model_name.endswith("_gsp_sum"))
     )
     return is_regional
 


### PR DESCRIPTION
# Pull Request

## Description

Currently all PVNet models start with either `pvnet_v2_*` or `pvnet_day_ahead_*` this change means that the probabilistic and regional plot features will be available for the pvnet_day_ahead model outputs.  

## How Has This Been Tested?

No additional tests added 

