### PR TITLE
Update pvsite_forecast.py

### DIFF
--- a/src/pvsite_forecast.py
+++ b/src/pvsite_forecast.py
@@ -109,11 +109,11 @@ def pvsite_forecast_page():
             "Select site by", ("site_uuid", "client_site_name")
         )
 
-        if query_method == "site_uuid":
-            site_selection_uuid = st.sidebar.selectbox(
-                "Select sites by site_uuid",
-                site_uuids,
-            )
+       if query_method == "site_uuid":
+             site_selection_uuid = st.sidebar.selectbox(
+                 "Select sites by site_uuid",
+                 site_uuids,
+             )
 
         else:
          


### PR DESCRIPTION
This PR updates all occurrences of "T" in pvsite_forecast.py so that:

Sidebar resample options are now ["15min", "30min"] instead of ["15T", "30T"].

User caption prompts the user to resample to "15min" instead of "15T".

All calls to .resample(resample) and any literal frequency strings use "min" rather than the deprecated "T".

# Pull Request

## Description

_Please delete the italicised instruction text!
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context. List any dependencies that are required for this change._

Fixes #

## How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration_

- [ ] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
