### PR TITLE
Update forecast page to 342 gsps

### DIFF
--- a/src/forecast.py
+++ b/src/forecast.py
@@ -47,7 +47,7 @@ def forecast_page():
     with connection.get_session() as session:
         # Add dropdown to select GSP region
         locations = get_all_locations(session=session)
-        locations = [Location.from_orm(loc) for loc in locations if loc.gsp_id < 318]
+        locations = [Location.from_orm(loc) for loc in locations if loc.gsp_id < 342]
         gsp_ids = [loc.gsp_id for loc in locations]
         gsp_names = [loc.region_name for loc in locations]
 
@@ -320,14 +320,14 @@ def get_pvlive_data(end_datetime, gsp_id, session, start_datetime):
     )
     pvlive_gsp_sum_inday = get_gsp_yield_sum(
         session=session,
-        gsp_ids=list(range(1, 318)),
+        gsp_ids=list(range(1, 342)),
         start_datetime_utc=start_datetime,
         end_datetime_utc=end_datetime,
         regime="in-day",
     )
     pvlive_gsp_sum_dayafter = get_gsp_yield_sum(
         session=session,
-        gsp_ids=list(range(1, 318)),
+        gsp_ids=list(range(1, 342)),
         start_datetime_utc=start_datetime,
         end_datetime_utc=end_datetime,
         regime="day-after",


### PR DESCRIPTION
# Pull Request

## Description

_Updated hardcoded GSP ID limits from 318 to 342 in forecast.py to support 342 GSPs as per issue #378._

Fixes #378 

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have checked my code and corrected any misspellings
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
