### PR TITLE
fix password input string used in secrets.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ uv sync
 3. Create a login secret:
 
 ```shell
-echo "password = example" > src/.streamlit/secrets.toml
+echo 'password = "example"' > src/.streamlit/secrets.toml
 ```
 
 4. Run the app:
@@ -68,7 +68,7 @@ pip install -e .
 Create a login secret:
 
 ```shell
-echo "password = example" > src/.streamlit/secrets.toml
+echo 'password = "example"' > src/.streamlit/secrets.toml
 ```
 
 Run app:
@@ -122,7 +122,7 @@ SHOW_PVNET_GSP_SUM=0          # Set this to 1 if you want to show pvnet_gsp_sum 
 3. Create a `secrets.toml` file in the `src/.streamlit` directory and add the following line:
 
 ```shell
-echo "password = example" > src/.streamlit/secrets.toml
+echo 'password = "example"' > src/.streamlit/secrets.toml
 ```
 
 4. Build the Docker image and start the app:


### PR DESCRIPTION
# Pull Request

## Description
after launching the dashboard in localhost, it asks for the password, which is generated through the echo command as example, but the dashboard generates error as streamlit tries to access the password as st.secrets["password"] which expects quoted example text, but that is not what echo command generated in the secrets file, making dashboard to reject the login, error reference is attached.
<img width="1818" height="796" alt="Screenshot 2025-12-17 184429" src="https://github.com/user-attachments/assets/8a2bdd7d-c565-4989-90ff-d29449a71bee" />

# To Reproduce
launch the dashboard in local host and enter password as example, it will fail, throwing an error

## How Has This Been Tested?
rebuild the dashboard with uv and entered the password example (without quotes) logs into the dashboard now


_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
