### PR TITLE
fix docker compose to setup dashboard

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,16 +14,6 @@ services:
       ENVIRONMENT: "development" # Can be "development" or "production"
     volumes:
       - ./src:/app/src # Mounting the src directory inside the container
-    command:
-      [
-        "streamlit",
-        "run",
-        "src/main.py",
-        "--server.port=8501",
-        "--browser.serverAddress=0.0.0.0",
-        "--server.address=0.0.0.0",
-        "--server.enableCORS=False"
-      ]
     networks:
       - analysis-net
 


### PR DESCRIPTION
# Pull Request

## Description
the docker build was broken, the docker-compose up --build failed and threw the error attached
<img width="973" height="234" alt="Screenshot 2025-12-18 172258" src="https://github.com/user-attachments/assets/a2fbc07a-789e-442e-813f-857c70d7c587" />

this happens as the docker-compose.yml file overrides the CMD command that is already at the bottom of the DockerFile which is responsible for the allocation of port and streamlit launch command, the change made now help the image to build using the docker-compose.yml and launches the port and streamlit using DockerFile causing no issues

# To Reproduce error
1. clone repo
2. cd analysis-dashboard
3. create .env and secrets.toml as per readme
4. docker-compose up --build

## How Has This Been Tested?

rebuilt the image as per the readme, and the streamlit app is ready on the port 

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
