### PR TITLE
Test: skip Docker-dependent tests when Docker daemon is unavailable

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import datetime as dt
 
+import docker
 import pytest
 from nowcasting_datamodel.models.base import Base_Forecast
 from nowcasting_datamodel.models.metric import MetricSQL, MetricValueSQL, DatetimeIntervalSQL
@@ -11,9 +12,21 @@ from sqlalchemy.orm import Session
 from testcontainers.postgres import PostgresContainer
 
 
+def _is_docker_available() -> bool:
+    try:
+        client = docker.from_env()
+        client.ping()
+        return True
+    except Exception:
+        return False
+
+
 @pytest.fixture(scope="session")
 def engine():
     """Database engine fixture."""
+    if not _is_docker_available():
+        pytest.skip("Docker daemon is not available; skipping Docker-dependent tests")
+
     with PostgresContainer("postgres:14.5") as postgres:
         # TODO need to setup postgres database with docker
         url = postgres.get_connection_url()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,5 +1,6 @@
 import time
 import uuid
+import docker
 import pytest
 from testcontainers.postgres import PostgresContainer
 from testcontainers.core.container import DockerContainer
@@ -11,6 +12,15 @@ from dp_sdk.ocf import dp
 from grpclib.client import Channel
 
 
+def _is_docker_available() -> bool:
+    try:
+        client = docker.from_env()
+        client.ping()
+        return True
+    except Exception:
+        return False
+
+
 @pytest_asyncio.fixture(scope="session")
 async def dp_channel():
     """
@@ -18,6 +28,9 @@ async def dp_channel():
     This fixture uses `testcontainers` to start a fresh PostgreSQL container and provides
     the connection URL dynamically for use in other fixtures.
     """
+
+    if not _is_docker_available():
+        pytest.skip("Docker daemon is not available; skipping integration tests")
 
     # we use a specific postgres image with postgis and pgpartman installed
     # TODO make a release of this, not using logging tag.


### PR DESCRIPTION
# Pull Request

## Description
This PR updates Docker-dependent test fixtures to skip gracefully when the Docker daemon is unavailable, instead of failing during setup with Docker exceptions.

## Summary of Changes
- Added a Docker availability check helper and early skip in `conftest.py` (lines 15–30).
- Added a Docker availability check helper and early skip in `conftest.py` (lines 15–33).

## Motivation and Context
Local and CI environments without Docker were producing hard test errors during fixture setup.  
Skipping these tests when Docker is unavailable provides a clearer signal and keeps test runs usable.

## Dependencies
- No new package dependencies were added.
- Behavior depends on Docker daemon availability at runtime.

Fixes #397 

---

## How Has This Been Tested?

Ran targeted Docker-dependent tests after the change:

```bash
python -m pytest tests/integration/test_get_data.py \
tests/integration/test_sites_toolbox.py \
tests/integration/test_pinball_and_exceedance.py \
tests/integration/test_ramp_rate.py -q
```

**Result:**
- 30 skipped
- 0 Docker setup errors (expected on a machine without Docker daemon)

---

## Data Processing Checks
- Yes (Not applicable for this test-fixture-only change)

---

## Checklist
- [x] My code follows OCF's coding style guidelines  
- [x] I have performed a self-review of my own code  
- [ ] I have made corresponding changes to the documentation  
- [ ] I have added tests that prove my fix is effective or that my feature works  
- [x] I have checked my code and corrected any misspellings
