### PR TITLE
test: register integration pytest marker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,3 +84,6 @@ python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
 pythonpath = ["src"]
+markers = [
+    "integration: marks tests that require integration dependencies",
+]


### PR DESCRIPTION
# Pull Request

## Description
This PR registers the `integration` pytest marker in the project pytest configuration to remove `PytestUnknownMarkWarning` during test collection.

## Summary of Changes
- Added marker definition in `pyproject.toml` under `[tool.pytest.ini_options]`:
  - `integration`: marks tests that require integration dependencies

## Motivation and Context
Multiple tests are decorated with `@pytest.mark.integration`.  
Without marker registration, pytest emits `PytestUnknownMarkWarning`, which creates unnecessary noise and reduces the clarity of test output in both local and CI environments.

## Dependencies
None.

Fixes #399 
---

## How Has This Been Tested?

Ran:

```bash
python -m pytest tests/test_elexon_plot.py -q
```

Verified:
- Tests pass successfully
- `PytestUnknownMarkWarning` for `integration` marker no longer appears

---

## Data Processing Checks
- Yes (Not applicable)

---

## Checklist
- [x] My code follows OCF's coding style guidelines  
- [x] I have performed a self-review of my own code  
- [ ] I have made corresponding changes to the documentation  
- [ ] I have added tests that prove my fix is effective or that my feature works  
- [x] I have checked my code and corrected any misspellings