### PR TITLE
fix: avoid pandas SettingWithCopyWarning in Elexon preprocessing

### DIFF
--- a/src/plots/elexon_plots.py
+++ b/src/plots/elexon_plots.py
@@ -106,7 +106,7 @@ def fetch_forecast_data(
             return pd.DataFrame()
 
         df = pd.DataFrame([item.to_dict() for item in response.data])
-        solar_df = df[df["business_type"] == "Solar generation"]
+        solar_df = df[df["business_type"] == "Solar generation"].copy()
         solar_df["start_time"] = pd.to_datetime(solar_df["start_time"])
         solar_df = solar_df.set_index("start_time")
 


### PR DESCRIPTION
# Pull Request

## Description
This PR fixes a pandas `SettingWithCopyWarning` in Elexon forecast preprocessing by ensuring mutations are performed on an explicit copy of the filtered DataFrame.

This prevents ambiguous chained-assignment behavior and makes preprocessing deterministic without changing expected output.

Fixes #401

---

## How Has This Been Tested?

Ran:

```bash
python -m pytest tests/test_elexon_plot.py -q
```

Result:
- **8 passed**
- The `SettingWithCopyWarning` from this preprocessing path no longer appears.

---

## Data Processing Checks
- Yes (Not applicable for this warning-only code path change)

---

## Checklist
- [x] My code follows OCF's coding style guidelines  
- [x] I have performed a self-review of my own code  
- [ ] I have made corresponding changes to the documentation  
- [ ] I have added tests that prove my fix is effective or that my feature works  
- [x] I have checked my code and corrected any misspellings