### PR TITLE
Fix DP forecast selection to match Forecast page

### DIFF
--- a/src/dataplatform/forecast/plot.py
+++ b/src/dataplatform/forecast/plot.py
@@ -8,6 +8,32 @@ import plotly.graph_objects as go
 from dataplatform.forecast.constant import colours
 
 
+def _pick_latest_forecast_per_target(
+    forecast_df: pd.DataFrame,
+) -> pd.DataFrame:
+    """Pick one forecast row per target and forecaster.
+
+    We match the classic Forecast page behavior by choosing the lowest horizon,
+    and for ties choosing the most recently created forecast.
+    """
+    if forecast_df.empty:
+        return forecast_df
+
+    sort_columns = ["target_timestamp_utc", "forecaster_name", "horizon_mins"]
+    ascending = [True, True, True]
+
+    if "created_timestamp_utc" in forecast_df.columns:
+        sort_columns.append("created_timestamp_utc")
+        # latest created forecast should win when horizon ties
+        ascending.append(False)
+
+    sorted_df = forecast_df.sort_values(by=sort_columns, ascending=ascending)
+    return sorted_df.drop_duplicates(
+        subset=["target_timestamp_utc", "forecaster_name"],
+        keep="first",
+    )
+
+
 def make_time_series_trace(
     fig: go.Figure,
     forecaster_df: pd.DataFrame,
@@ -79,29 +105,21 @@ def plot_forecast_time_series(
     This make a plot of the raw forecasts and observations, for mulitple forecast.
     """
     if selected_forecast_type == "Current":
-        # Choose current forecast
-        # this is done by selecting the unique target_timestamp_utc with the the lowest horizonMins
-        # it should also be unique for each forecasterFullName
-        current_forecast_df = all_forecast_data_df.loc[
-            all_forecast_data_df.groupby(["target_timestamp_utc", "forecaster_name"])[
-                "horizon_mins"
-            ].idxmin()
-        ]
+        # Choose current forecast per target by lowest horizon.
+        # If there are duplicate rows at the same horizon, choose the latest created one.
+        current_forecast_df = _pick_latest_forecast_per_target(all_forecast_data_df)
     elif selected_forecast_type == "Horizon":
         # Choose horizon forecast
         if strict_horizon_filtering:
-            current_forecast_df = all_forecast_data_df[
+            horizon_filtered_df = all_forecast_data_df[
                 all_forecast_data_df["horizon_mins"] == selected_forecast_horizon
             ]
         else:
-            current_forecast_df = all_forecast_data_df[
+            horizon_filtered_df = all_forecast_data_df[
                 all_forecast_data_df["horizon_mins"] >= selected_forecast_horizon
             ]
-        current_forecast_df = current_forecast_df.loc[
-            current_forecast_df.groupby(["target_timestamp_utc", "forecaster_name"])[
-                "horizon_mins"
-            ].idxmin()
-        ]
+
+        current_forecast_df = _pick_latest_forecast_per_target(horizon_filtered_df)
     elif selected_forecast_type == "t0":
         current_forecast_df = all_forecast_data_df[
             all_forecast_data_df["init_timestamp"].isin(selected_t0s)

--- a/tests/test_dp_forecast_plot.py
+++ b/tests/test_dp_forecast_plot.py
@@ -1,0 +1,101 @@
+from datetime import UTC, datetime
+
+import pandas as pd
+
+from dataplatform.forecast.plot import plot_forecast_time_series
+
+
+def _make_forecast_df(rows: list[dict]) -> pd.DataFrame:
+    df = pd.DataFrame(rows)
+    df["target_timestamp_utc"] = pd.to_datetime(df["target_timestamp_utc"])
+    df["created_timestamp_utc"] = pd.to_datetime(df["created_timestamp_utc"])
+    return df
+
+
+def test_current_forecast_prefers_latest_created_when_horizon_ties():
+    forecast_df = _make_forecast_df(
+        [
+            {
+                "target_timestamp_utc": datetime(2026, 3, 11, 12, 30, tzinfo=UTC),
+                "forecaster_name": "pvnet_v2",
+                "horizon_mins": 0,
+                "created_timestamp_utc": datetime(2026, 3, 11, 11, 0, tzinfo=UTC),
+                "p50_watts": 9_800,
+            },
+            {
+                "target_timestamp_utc": datetime(2026, 3, 11, 12, 30, tzinfo=UTC),
+                "forecaster_name": "pvnet_v2",
+                "horizon_mins": 0,
+                "created_timestamp_utc": datetime(2026, 3, 11, 11, 30, tzinfo=UTC),
+                "p50_watts": 10_300,
+            },
+            {
+                "target_timestamp_utc": datetime(2026, 3, 11, 12, 30, tzinfo=UTC),
+                "forecaster_name": "pvnet_v2",
+                "horizon_mins": 30,
+                "created_timestamp_utc": datetime(2026, 3, 11, 10, 30, tzinfo=UTC),
+                "p50_watts": 9_500,
+            },
+        ],
+    )
+
+    fig = plot_forecast_time_series(
+        all_forecast_data_df=forecast_df,
+        all_observations_df=pd.DataFrame(),
+        forecaster_names=["pvnet_v2"],
+        observer_names=[],
+        scale_factor=1.0,
+        units="W",
+        selected_forecast_type="Current",
+        selected_forecast_horizon=0,
+        selected_t0s=None,
+        show_probabilistic=False,
+    )
+
+    assert len(fig.data) == 1
+    assert list(fig.data[0].y) == [10_300]
+
+
+def test_horizon_forecast_prefers_latest_created_for_selected_horizon():
+    forecast_df = _make_forecast_df(
+        [
+            {
+                "target_timestamp_utc": datetime(2026, 3, 11, 12, 30, tzinfo=UTC),
+                "forecaster_name": "pvnet_v2",
+                "horizon_mins": 0,
+                "created_timestamp_utc": datetime(2026, 3, 11, 11, 0, tzinfo=UTC),
+                "p50_watts": 9_900,
+            },
+            {
+                "target_timestamp_utc": datetime(2026, 3, 11, 12, 30, tzinfo=UTC),
+                "forecaster_name": "pvnet_v2",
+                "horizon_mins": 0,
+                "created_timestamp_utc": datetime(2026, 3, 11, 11, 15, tzinfo=UTC),
+                "p50_watts": 10_200,
+            },
+            {
+                "target_timestamp_utc": datetime(2026, 3, 11, 12, 30, tzinfo=UTC),
+                "forecaster_name": "pvnet_v2",
+                "horizon_mins": 30,
+                "created_timestamp_utc": datetime(2026, 3, 11, 10, 30, tzinfo=UTC),
+                "p50_watts": 9_600,
+            },
+        ],
+    )
+
+    fig = plot_forecast_time_series(
+        all_forecast_data_df=forecast_df,
+        all_observations_df=pd.DataFrame(),
+        forecaster_names=["pvnet_v2"],
+        observer_names=[],
+        scale_factor=1.0,
+        units="W",
+        selected_forecast_type="Horizon",
+        selected_forecast_horizon=0,
+        selected_t0s=None,
+        show_probabilistic=False,
+        strict_horizon_filtering=True,
+    )
+
+    assert len(fig.data) == 1
+    assert list(fig.data[0].y) == [10_200]


### PR DESCRIPTION
## Description
This PR fixes a mismatch where the **Forecast** and **DP Forecast** pages could display different forecast values for the same **forecaster, timestamp, and horizon selection**.

### Root Cause
The DP Forecast selection logic did not consistently choose the **latest created forecast** when duplicate rows existed for the same **target timestamp** and **forecaster**.

### What Changed
Added deterministic selection logic in DP Forecast plotting:

- Select the **lowest horizon** per `target_timestamp + forecaster`
- When multiple rows share the same horizon, select the **latest `created` timestamp**

This logic is now applied to both:

- **Current mode**
- **Horizon mode**

Additional improvements:
- Added **regression tests** to prevent this drift in the future.

---

## Motivation and Context
Users expect **consistent forecast values** across the **Forecast** and **DP Forecast** pages when inputs are equivalent.

This update aligns the **DP Forecast selection logic** with the **latest-forecast semantics** already used on the Forecast page.

---

## Dependencies
None.

---

## Related Issue
Fixes #405

---

## How Has This Been Tested?

### Automated Tests
Command executed:
python -m pytest tests/test_dp_forecast_plot.py -q

Result:

### Test Coverage
The tests verify that:

- **Current mode** selects the **latest created forecast** when horizon ties exist.
- **Horizon mode** selects the **latest created forecast** for the selected horizon when duplicates exist.

### Manual Verification
- Compared selection logic paths between **Forecast** and **DP Forecast**.
- Confirmed that DP selection now mirrors **Forecast latest-selection behavior**.

---

## Data Processing Validation
- ✅ Sanity check performed to confirm forecast selection behaves as expected.

---

## Checklist
- [x] My code follows OCF's coding style guidelines  
- [x] I have performed a self-review of my own code  
- [ ] I have made corresponding changes to the documentation  
- [x] I have added tests that prove my fix is effective or that my feature works  
- [x] I have checked my code and corrected any misspellings