### PR TITLE
fix: replace deprecated datetime.utcnow() with timezone-aware alternatives

### DIFF
--- a/src/mlmodel.py
+++ b/src/mlmodel.py
@@ -10,7 +10,7 @@ from pvsite_datamodel.read.site import get_all_sites
 from pvsite_datamodel.sqlmodels import GenerationSQL, MLModelSQL
 
 def color_survived(val):
-    now = pd.Timestamp.utcnow()
+    now = pd.Timestamp.now(tz="UTC")
     color = (
         "#ee6b6e"
         if val < now - pd.Timedelta("4H")

--- a/src/plots/elexon_plots.py
+++ b/src/plots/elexon_plots.py
@@ -1,6 +1,6 @@
 from typing import Callable, List, Optional, Tuple, Union
 import pandas as pd
-from datetime import datetime, date, timedelta
+from datetime import datetime, date, timedelta, timezone
 from plotly import graph_objects as go
 import streamlit as st
 from elexonpy.api_client import ApiClient
@@ -132,7 +132,7 @@ def determine_start_and_end_datetimes(
     - start_datetime_utc: datetime object in UTC
     - end_datetime_utc: datetime object in UTC
     """
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
 
     # Determine start_datetime_utc
     if start_datetimes:

--- a/src/pvsite_forecast.py
+++ b/src/pvsite_forecast.py
@@ -155,14 +155,14 @@ def pvsite_forecast_page():
         capacity_kw = site.capacity_kw  # Extract capacity dynamically
 
         if forecast_type == "Latest":
-            created = pd.Timestamp.utcnow().ceil("15min")
+            created = pd.Timestamp.now(tz="UTC").ceil("15min")
             created = created.astimezone(timezone.utc)
             created = created.astimezone(timezone_selected)
             created = created.replace(tzinfo=None)
             created = st.sidebar.text_input("Created Before", created)
 
             if created == "":
-                created = pd.Timestamp.utcnow().ceil("15min")
+                created = pd.Timestamp.now(tz="UTC").ceil("15min")
                 created = created.astimezone(timezone.utc)
                 created = created.astimezone(timezone_selected)
                 created = created.replace(tzinfo=None)

--- a/tests/test_elexon_plot.py
+++ b/tests/test_elexon_plot.py
@@ -1,7 +1,7 @@
 from unittest.mock import Mock, patch
 import pandas as pd
 import pytest
-from datetime import datetime
+from datetime import datetime, timezone
 from plotly import graph_objects as go
 from plots.elexon_plots import  add_elexon_plot, determine_start_and_end_datetimes, fetch_forecast_data
 from elexonpy.api_client import ApiClient
@@ -9,7 +9,7 @@ from elexonpy.api.generation_forecast_api import GenerationForecastApi
 
 def test_determine_start_and_end_datetimes_no_input():
     # Test with no input
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     start, end = determine_start_and_end_datetimes([], [])
     assert start < now, "Start time should be before current time."
     assert end > start, "End time should be after start time."


### PR DESCRIPTION
Fixes #403

Replaces deprecated `datetime.utcnow()` and `pd.Timestamp.utcnow()` with timezone-aware alternatives across the Elexon plotting flow and related modules:

- `src/plots/elexon_plots.py` — `datetime.now(timezone.utc)`
- `tests/test_elexon_plot.py` — `datetime.now(timezone.utc)`
- `src/pvsite_forecast.py` — `pd.Timestamp.now(tz="UTC")`
- `src/mlmodel.py` — `pd.Timestamp.now(tz="UTC")`

`datetime.utcnow()` was deprecated in Python 3.12 as it returns naive datetimes despite implying UTC. `pd.Timestamp.utcnow()` was deprecated in pandas 2.1 for the same reason.