### PR TITLE
fix: replace deprecated datetime.utcnow() in Elexon plotting and tests

### DIFF
--- a/src/plots/elexon_plots.py
+++ b/src/plots/elexon_plots.py
@@ -1,6 +1,6 @@
 from typing import Callable, List, Optional, Tuple, Union
 import pandas as pd
-from datetime import datetime, date, timedelta
+from datetime import datetime, date, timedelta, UTC
 from plotly import graph_objects as go
 import streamlit as st
 from elexonpy.api_client import ApiClient
@@ -132,7 +132,7 @@ def determine_start_and_end_datetimes(
     - start_datetime_utc: datetime object in UTC
     - end_datetime_utc: datetime object in UTC
     """
-    now = datetime.utcnow()
+    now = datetime.now(UTC)
 
     # Determine start_datetime_utc
     if start_datetimes:

--- a/tests/test_elexon_plot.py
+++ b/tests/test_elexon_plot.py
@@ -1,7 +1,7 @@
 from unittest.mock import Mock, patch
 import pandas as pd
 import pytest
-from datetime import datetime
+from datetime import datetime, UTC
 from plotly import graph_objects as go
 from plots.elexon_plots import  add_elexon_plot, determine_start_and_end_datetimes, fetch_forecast_data
 from elexonpy.api_client import ApiClient
@@ -9,7 +9,7 @@ from elexonpy.api.generation_forecast_api import GenerationForecastApi
 
 def test_determine_start_and_end_datetimes_no_input():
     # Test with no input
-    now = datetime.utcnow()
+    now = datetime.now(UTC)
     start, end = determine_start_and_end_datetimes([], [])
     assert start < now, "Start time should be before current time."
     assert end > start, "End time should be after start time."


### PR DESCRIPTION
## Summary
Replace deprecated `datetime.utcnow()` with timezone-aware `datetime.now(UTC)` in Elexon plotting code and tests, ensuring Python 3.12+ compatibility.

## Root Cause
`datetime.utcnow()` is deprecated in Python 3.12+ and emits deprecation warnings. The project specifies `requires-python = ">=3.12"`, so this should use the timezone-aware alternative.

## Changes
- `src/plots/elexon_plots.py`: `from datetime import ... UTC` + `datetime.now(UTC)`
- `tests/test_elexon_plot.py`: `from datetime import ... UTC` + `datetime.now(UTC)`

## Why This Is Safe
The new call returns a timezone-aware datetime in the same UTC offset that `datetime.utcnow()` returned as naive. All start/end datetime calculations remain functionally equivalent. No test logic is changed — only the `now` reference value is updated.

## Testing
- Pre-commit checks pass
- Pre-push checks pass (lint + TypeScript)

## Related
- Fixes #403