### PR TITLE
fix(dp_forecasts): Better state handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ extra-index-url = ["https://pypi.org/simple"]
 
 [tool.uv.sources]
 
-dp-sdk = { url = "https://github.com/openclimatefix/data-platform/releases/download/v0.25.0/dp_sdk-0.25.0-py3-none-any.whl" }
+dp-sdk = { url = "https://github.com/openclimatefix/data-platform/releases/download/v0.28.0/dp_sdk-0.28.0-py3-none-any.whl" }
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py"]

--- a/src/dataplatform/forecast/backend.py
+++ b/src/dataplatform/forecast/backend.py
@@ -1,0 +1,147 @@
+"""Backend logic for the Data Platform Forecasting Explorer app, including data fetching and processing."""
+
+import asyncio
+import datetime
+
+import pandas as pd
+import streamlit as st
+
+from ocf import dp
+
+
+async def fetch_timeseries(
+    client: dp.DataPlatformDataServiceStub,
+    location_uuid: str,
+    start_date: datetime.datetime,
+    end_date: datetime.datetime,
+    horizon_mins: int,
+    forecasters: list[dp.Forecaster],
+    init_times_utc: list[datetime.datetime] | None = None,
+) -> pd.DataFrame:
+    """Directly calls GetForecastAsTimeseries for selected models and init times."""
+
+    time_window = dp.TimeWindow(
+        start_timestamp_utc=start_date, end_timestamp_utc=end_date
+    )
+
+    times_to_fetch = init_times_utc if init_times_utc else [None]
+
+    async def fetch_one(
+        forecaster_obj: dp.Forecaster, init_time: datetime.datetime | None
+    ):
+        req = dp.GetForecastAsTimeseriesRequest(
+            location_uuid=location_uuid,
+            energy_source=dp.EnergySource.SOLAR,
+            horizon_mins=horizon_mins,
+            time_window=time_window,
+            forecaster=forecaster_obj,
+            initialization_timestamp_utc=init_time,
+        )
+
+        try:
+            resp = await client.get_forecast_as_timeseries(req)
+            rows = []
+            for val in resp.values:
+                row = {
+                    "target_timestamp_utc": val.target_timestamp_utc,
+                    "initialization_timestamp_utc": val.initialization_timestamp_utc,
+                    "created_timestamp_utc": val.created_timestamp_utc,
+                    "effective_capacity_watts": val.effective_capacity_watts,
+                    "forecaster_name": forecaster_obj.forecaster_name,
+                    "location_uuid": resp.location_uuid,
+                    "horizon_mins": (
+                        val.target_timestamp_utc - val.initialization_timestamp_utc
+                    ).total_seconds()
+                    // 60,
+                    "p50_watts": int(
+                        val.p50_value_fraction * val.effective_capacity_watts
+                    ),
+                }
+
+                if val.other_statistics_fractions:
+                    row.update(
+                        {
+                            f"{k}_watts": int(v * val.effective_capacity_watts)
+                            for k, v in val.other_statistics_fractions.items()
+                        }
+                    )
+                rows.append(row)
+
+            return rows
+        except Exception as e:
+            time_str = init_time.isoformat() if init_time else "Latest"
+            st.error(
+                f"Failed to fetch {forecaster_obj.forecaster_name} at {time_str}: {e}"
+            )
+            return []
+
+    tasks = [fetch_one(f, t) for f in forecasters for t in times_to_fetch]
+
+    results = await asyncio.gather(*tasks)
+    all_rows = [item for sublist in results for item in sublist]
+
+    df = pd.DataFrame(all_rows)
+    if not df.empty:
+        df["target_timestamp_utc"] = pd.to_datetime(df["target_timestamp_utc"])
+        if "initialization_timestamp_utc" in df.columns:
+            df["initialization_timestamp_utc"] = pd.to_datetime(
+                df["initialization_timestamp_utc"]
+            )
+
+    return df
+
+
+async def fetch_observations(
+    client: dp.DataPlatformDataServiceStub,
+    location_uuid: str,
+    start_date: datetime.datetime,
+    end_date: datetime.datetime,
+    observers: list[str],
+    energy_source: dp.EnergySource = dp.EnergySource.SOLAR,
+) -> pd.DataFrame:
+    """Directly calls GetObservationsAsTimeseries for selected observers."""
+
+    time_window = dp.TimeWindow(
+        start_timestamp_utc=start_date, end_timestamp_utc=end_date
+    )
+
+    # Run requests concurrently for all selected observers
+    async def fetch_one(obs_name: str):
+        req = dp.GetObservationsAsTimeseriesRequest(
+            location_uuid=location_uuid,
+            observer_name=obs_name,
+            energy_source=energy_source,
+            time_window=time_window,
+        )
+
+        try:
+            resp = await client.get_observations_as_timeseries(req)
+            rows = []
+            for val in resp.values:
+                rows.append(
+                    {
+                        "target_timestamp_utc": val.timestamp_utc,
+                        "value_fraction": val.value_fraction,
+                        "effective_capacity_watts": val.effective_capacity_watts,
+                        "observer_name": obs_name,
+                        "location_uuid": resp.location_uuid,
+                        "value_watts": int(
+                            val.value_fraction * val.effective_capacity_watts
+                        ),
+                    }
+                )
+            return rows
+        except Exception as e:
+            st.error(f"Failed to fetch observations for {obs_name}: {e}")
+            return []
+
+    results = await asyncio.gather(*[fetch_one(obs) for obs in observers])
+    all_rows = [item for sublist in results for item in sublist]
+
+    df = pd.DataFrame(all_rows)
+
+    if not df.empty:
+        df["target_timestamp_utc"] = pd.to_datetime(df["target_timestamp_utc"])
+
+    return df
+

--- a/src/dataplatform/forecast/backend.py
+++ b/src/dataplatform/forecast/backend.py
@@ -23,17 +23,30 @@ async def fetch_timeseries(
     time_window = dp.TimeWindow(
         start_timestamp_utc=start_date, end_timestamp_utc=end_date
     )
+    time_windows = []
+    current_start = start_date
+    while current_start < end_date:
+        current_end = min(current_start + datetime.timedelta(days=7), end_date)
+        time_windows.append(
+            dp.TimeWindow(
+                start_timestamp_utc=current_start,
+                end_timestamp_utc=current_end
+            )
+        )
+        current_start = current_end
 
     times_to_fetch = init_times_utc if init_times_utc else [None]
 
     async def fetch_one(
-        forecaster_obj: dp.Forecaster, init_time: datetime.datetime | None
+        forecaster_obj: dp.Forecaster,
+        window: dp.TimeWindow,
+        init_time: datetime.datetime | None
     ):
         req = dp.GetForecastAsTimeseriesRequest(
             location_uuid=location_uuid,
             energy_source=dp.EnergySource.SOLAR,
             horizon_mins=horizon_mins,
-            time_window=time_window,
+            time_window=window,
             forecaster=forecaster_obj,
             initialization_timestamp_utc=init_time,
         )
@@ -75,7 +88,7 @@ async def fetch_timeseries(
             )
             return []
 
-    tasks = [fetch_one(f, t) for f in forecasters for t in times_to_fetch]
+    tasks = [fetch_one(f, w, t) for f in forecasters for t in times_to_fetch for w in time_windows]
 
     results = await asyncio.gather(*tasks)
     all_rows = [item for sublist in results for item in sublist]
@@ -87,6 +100,9 @@ async def fetch_timeseries(
             df["initialization_timestamp_utc"] = pd.to_datetime(
                 df["initialization_timestamp_utc"]
             )
+        df = df.sort_values(
+            ["forecaster_name", "initialization_timestamp_utc", "target_timestamp_utc"]
+        ).reset_index(drop=True)
 
     return df
 
@@ -104,14 +120,26 @@ async def fetch_observations(
     time_window = dp.TimeWindow(
         start_timestamp_utc=start_date, end_timestamp_utc=end_date
     )
+    time_windows = []
+    current_start = start_date
+    while current_start < end_date:
+        current_end = min(current_start + datetime.timedelta(days=7), end_date)
+        time_windows.append(
+            dp.TimeWindow(
+                start_timestamp_utc=current_start,
+                end_timestamp_utc=current_end
+            )
+        )
+        current_start = current_end
+
 
     # Run requests concurrently for all selected observers
-    async def fetch_one(obs_name: str):
+    async def fetch_one(obs_name: str, window: dp.TimeWindow):
         req = dp.GetObservationsAsTimeseriesRequest(
             location_uuid=location_uuid,
             observer_name=obs_name,
             energy_source=energy_source,
-            time_window=time_window,
+            time_window=window,
         )
 
         try:
@@ -135,13 +163,14 @@ async def fetch_observations(
             st.error(f"Failed to fetch observations for {obs_name}: {e}")
             return []
 
-    results = await asyncio.gather(*[fetch_one(obs) for obs in observers])
+    results = await asyncio.gather(*[fetch_one(obs, w) for obs in observers for w in time_windows])
     all_rows = [item for sublist in results for item in sublist]
 
     df = pd.DataFrame(all_rows)
 
     if not df.empty:
         df["target_timestamp_utc"] = pd.to_datetime(df["target_timestamp_utc"])
+        df = df.sort_values(["observer_name", "target_timestamp_utc"]).reset_index(drop=True)
 
     return df
 

--- a/src/dataplatform/forecast/main.py
+++ b/src/dataplatform/forecast/main.py
@@ -1,17 +1,16 @@
 """Data Platform Forecast Streamlit Page Main Code."""
 
 import asyncio
-import grpc
 import os
+import datetime
 
 import pandas as pd
 import streamlit as st
-from ocf import dp
 from grpclib.client import Channel
-from ocf.dp.dp_data import service_pb2_grpc
+
+from ocf import dp
 
 from dataplatform.forecast.constant import metrics, observer_names
-from dataplatform.forecast.data import align_t0, get_all_data
 from dataplatform.forecast.plot import (
     plot_forecast_metric_per_day,
     plot_forecast_metric_vs_horizon_minutes,
@@ -23,193 +22,346 @@ data_platform_host = os.getenv("DATA_PLATFORM_HOST", "localhost")
 data_platform_port = int(os.getenv("DATA_PLATFORM_PORT", "50051"))
 
 
+def init_session_state():
+    if "forecast_df" not in st.session_state:
+        st.session_state.forecast_df = None
+    if "observations_df" not in st.session_state:
+        st.session_state.observations_df = None
+    if "merged_metrics_df" not in st.session_state:
+        st.session_state.merged_metrics_df = None
+    if "fetch_time_stats" not in st.session_state:
+        st.session_state.fetch_time_stats = ""
+
+
+async def fetch_timeseries(
+    client: dp.DataPlatformDataServiceStub,
+    location_uuid: str,
+    start_date: datetime.datetime,
+    end_date: datetime.datetime,
+    horizon_mins: int,
+    forecasters: list[dp.Forecaster],
+    init_times_utc: list[datetime.datetime] | None = None,
+) -> pd.DataFrame:
+    """Directly calls GetForecastAsTimeseries for selected models and init times."""
+
+    time_window = dp.TimeWindow(
+        start_timestamp_utc=start_date, end_timestamp_utc=end_date
+    )
+
+    times_to_fetch = init_times_utc if init_times_utc else [None]
+
+    async def fetch_one(
+        forecaster_obj: dp.Forecaster, init_time: datetime.datetime | None
+    ):
+        req = dp.GetForecastAsTimeseriesRequest(
+            location_uuid=location_uuid,
+            energy_source=dp.EnergySource.SOLAR,
+            horizon_mins=horizon_mins,
+            time_window=time_window,
+            forecaster=forecaster_obj,
+            initialization_timestamp_utc=init_time,
+        )
+
+        try:
+            resp = await client.get_forecast_as_timeseries(req)
+            rows = []
+            for val in resp.values:
+                row = {
+                    "target_timestamp_utc": val.target_timestamp_utc,
+                    "initialization_timestamp_utc": val.initialization_timestamp_utc,
+                    "created_timestamp_utc": val.created_timestamp_utc,
+                    "effective_capacity_watts": val.effective_capacity_watts,
+                    "forecaster_name": forecaster_obj.forecaster_name,
+                    "location_uuid": resp.location_uuid,
+                    "horizon_mins": (
+                        val.target_timestamp_utc - val.initialization_timestamp_utc
+                    ).total_seconds()
+                    // 60,
+                    "p50_watts": int(
+                        val.p50_value_fraction * val.effective_capacity_watts
+                    ),
+                }
+
+                if val.other_statistics_fractions:
+                    row.update(
+                        {
+                            f"{k}_watts": int(v * val.effective_capacity_watts)
+                            for k, v in val.other_statistics_fractions.items()
+                        }
+                    )
+                rows.append(row)
+
+            return rows
+        except Exception as e:
+            time_str = init_time.isoformat() if init_time else "Latest"
+            st.error(
+                f"Failed to fetch {forecaster_obj.forecaster_name} at {time_str}: {e}"
+            )
+            return []
+
+    tasks = [fetch_one(f, t) for f in forecasters for t in times_to_fetch]
+
+    results = await asyncio.gather(*tasks)
+    all_rows = [item for sublist in results for item in sublist]
+
+    df = pd.DataFrame(all_rows)
+    if not df.empty:
+        df["target_timestamp_utc"] = pd.to_datetime(df["target_timestamp_utc"])
+        if "initialization_timestamp_utc" in df.columns:
+            df["initialization_timestamp_utc"] = pd.to_datetime(
+                df["initialization_timestamp_utc"]
+            )
+
+    return df
+
+
+async def fetch_observations(
+    client: dp.DataPlatformDataServiceStub,
+    location_uuid: str,
+    start_date: datetime.datetime,
+    end_date: datetime.datetime,
+    observers: list[str],
+    energy_source: dp.EnergySource = dp.EnergySource.SOLAR,
+) -> pd.DataFrame:
+    """Directly calls GetObservationsAsTimeseries for selected observers."""
+
+    time_window = dp.TimeWindow(
+        start_timestamp_utc=start_date, end_timestamp_utc=end_date
+    )
+
+    # Run requests concurrently for all selected observers
+    async def fetch_one(obs_name: str):
+        req = dp.GetObservationsAsTimeseriesRequest(
+            location_uuid=location_uuid,
+            observer_name=obs_name,
+            energy_source=energy_source,
+            time_window=time_window,
+        )
+
+        try:
+            resp = await client.get_observations_as_timeseries(req)
+            rows = []
+            for val in resp.values:
+                rows.append(
+                    {
+                        "target_timestamp_utc": val.timestamp_utc,
+                        "value_fraction": val.value_fraction,
+                        "effective_capacity_watts": val.effective_capacity_watts,
+                        "observer_name": obs_name,
+                        "location_uuid": resp.location_uuid,
+                        "value_watts": int(
+                            val.value_fraction * val.effective_capacity_watts
+                        ),
+                    }
+                )
+            return rows
+        except Exception as e:
+            st.error(f"Failed to fetch observations for {obs_name}: {e}")
+            return []
+
+    results = await asyncio.gather(*[fetch_one(obs) for obs in observers])
+    all_rows = [item for sublist in results for item in sublist]
+
+    df = pd.DataFrame(all_rows)
+
+    if not df.empty:
+        df["target_timestamp_utc"] = pd.to_datetime(df["target_timestamp_utc"])
+
+    return df
+
+
 def dp_forecast_page() -> None:
     """Wrapper function that is not async to call the main async function."""
+    init_session_state()
     asyncio.run(async_dp_forecast_page())
 
 
 async def async_dp_forecast_page() -> None:
     """Async Main function for the Data Platform Forecast Streamlit page."""
     st.title("Data Platform Forecast Page")
-    st.write("This is the forecast page from the Data Platform module. ")
+    st.write("This is the forecast page from the Data Platform module.")
 
     async with Channel(host=data_platform_host, port=data_platform_port) as channel:
         client = dp.DataPlatformDataServiceStub(channel)
-        grpc_channel = grpc.aio.insecure_channel(
-            target=data_platform_host + ":" + str(data_platform_port),
-        )
-        # This client is much faster for loading data
-        dp_client = service_pb2_grpc.DataPlatformDataServiceStub(grpc_channel)
 
-        setup_page_dict = await setup_page(client)
-        selected_location = setup_page_dict["selected_location"]
-        start_date = setup_page_dict["start_date"]
-        end_date = setup_page_dict["end_date"]
-        selected_forecasters = setup_page_dict["selected_forecasters"]
-        forecaster_names = setup_page_dict["forecaster_names"]
-        selected_metric = setup_page_dict["selected_metric"]
-        selected_forecast_type = setup_page_dict["selected_forecast_type"]
-        scale_factor = setup_page_dict["scale_factor"]
-        selected_forecast_horizon = setup_page_dict["selected_forecast_horizon"]
-        selected_t0s = setup_page_dict["selected_t0s"]
-        units = setup_page_dict["units"]
-        strict_horizon_filtering = setup_page_dict["strict_horizon_filtering"]
+        cfg = await setup_page(client)
+        st.divider()
+        st.subheader("1. Fetch Data")
 
-        ### 1. Get all the data ###
-        all_data_dict = await get_all_data(
-            client=dp_client,
-            start_date=start_date,
-            end_date=end_date,
-            selected_forecasters=selected_forecasters,
-            selected_location=selected_location,
-        )
-    
-    merged_df = all_data_dict["merged_df"]
-    all_forecast_data_df = all_data_dict["all_forecast_data_df"]
-    all_observations_df = all_data_dict["all_observations_df"]
-    forecast_seconds = all_data_dict["forecast_seconds"]
-    observation_seconds = all_data_dict["observation_seconds"]
+        if st.button("Fetch Forecast & Observations", type="primary"):
+            with st.spinner("Fetching data from gRPC API..."):
+                start_time = datetime.datetime.now()
 
-    st.write(f"Selected Location uuid: `{selected_location.location_uuid}`.")
-    st.write(
-        f"Fetched `{len(all_forecast_data_df)}` rows of forecast data \
-        in `{forecast_seconds:.2f}` seconds. \
-        Fetched `{len(all_observations_df)}` rows of observation data \
-        in `{observation_seconds:.2f}` seconds. \
-        We cache data for 5 minutes to speed up repeated requests.",
-    )
+                df_forecast = await fetch_timeseries(
+                    client=client,
+                    location_uuid=cfg.location.location_uuid,
+                    start_date=cfg.start_date,
+                    end_date=cfg.end_date,
+                    horizon_mins=cfg.forecast_horizon,
+                    forecasters=cfg.forecasters,
+                    init_times_utc=cfg.t0s,
+                )
 
-    # add download button
-    csv = merged_df.to_csv().encode("utf-8")
-    st.download_button(
-        label="⬇️ Download data",
-        data=csv,
-        file_name=f"site_forecast_{selected_location.location_uuid}_{start_date}_{end_date}.csv",
-        mime="text/csv",
-        help="Download the forecast and generation data as a CSV file.",
-    )
+                df_obs = await fetch_observations(
+                    client=client,
+                    location_uuid=cfg.location.location_uuid,
+                    start_date=cfg.start_date,
+                    end_date=cfg.end_date,
+                    observers=observer_names,
+                    energy_source=dp.EnergySource.SOLAR,
+                )
 
-    ### 2. Plot of raw forecast data. ###
-    st.header("Time Series Plot")
+                fetch_duration = (datetime.datetime.now() - start_time).total_seconds()
 
-    show_probabilistic = st.checkbox("Show Probabilistic Forecasts", value=True)
+                st.session_state.forecast_df = df_forecast
+                st.session_state.observations_df = df_obs
+                st.session_state.merged_metrics_df = None  # Reset metrics on new fetch
 
-    fig = plot_forecast_time_series(
-        all_forecast_data_df=all_forecast_data_df,
-        all_observations_df=all_observations_df,
-        forecaster_names=forecaster_names,
-        observer_names=observer_names,
-        scale_factor=scale_factor,
-        units=units,
-        selected_forecast_type=selected_forecast_type,
-        selected_forecast_horizon=selected_forecast_horizon,
-        selected_t0s=selected_t0s,
-        show_probabilistic=show_probabilistic,
-        strict_horizon_filtering=strict_horizon_filtering,
-    )
-    st.plotly_chart(fig)
+                st.session_state.fetch_time_stats = (
+                    f"Fetched `{len(df_forecast)}` forecast rows "
+                    f"in `{fetch_duration:.2f}` seconds."
+                )
 
-    ### 3. Summary Accuracy Graph. ###
-    st.header("Accuracy")
+        # Display fetch stats if they exist
+        if st.session_state.fetch_time_stats:
+            st.success(st.session_state.fetch_time_stats)
 
-    st.write(metrics)
+        # Ensure we have data before trying to plot
+        if (
+            st.session_state.forecast_df is not None
+            and not st.session_state.forecast_df.empty
+        ):
+            all_forecast_data_df = st.session_state.forecast_df
+            all_observations_df = st.session_state.observations_df
 
-    align_t0s = st.checkbox(
-        "Align t0s (Only common t0s across all forecaster are used)",
-        value=True,
-    )
-    if align_t0s:
-        merged_df = align_t0(merged_df)
+            csv = all_forecast_data_df.to_csv().encode("utf-8")
+            st.download_button(
+                label="⬇️ Download Raw Forecast Data",
+                data=csv,
+                file_name=f"site_forecast_{cfg.location.location_uuid}_{cfg.start_date}_{cfg.end_date}.csv",
+                mime="text/csv",
+            )
 
-    st.subheader("Metric vs Forecast Horizon")
+            st.header("Time Series Plot")
+            show_probabilistic = st.checkbox("Show Probabilistic Forecasts", value=True)
 
-    if selected_metric == "MAE":
-        show_sem = st.checkbox(
-            "Show Uncertainty",
-            value=True,
-            help="On the plot below show the uncertainty bands associated with the MAE. "
-            "This is done by looking at the "
-            "Standard Error of the Mean (SEM) of the absolute errors. "
-            "We plot the 5 to 95 percentile range around the MAE.",
-        )
-    else:
-        show_sem = False
+            fig = plot_forecast_time_series(
+                all_forecast_data_df=all_forecast_data_df,
+                all_observations_df=all_observations_df,
+                forecaster_names=[f.forecaster_name for f in cfg.forecasters],
+                observer_names=observer_names,
+                scale_factor=cfg.scale_factor,
+                units=cfg.units,
+                selected_forecast_type=cfg.forecast_type,
+                selected_forecast_horizon=cfg.forecast_horizon,
+                selected_t0s=cfg.t0s,
+                show_probabilistic=show_probabilistic,
+                strict_horizon_filtering=cfg.strict_horizon_filtering,
+            )
+            st.plotly_chart(fig)
 
-    summary_df = make_summary_data_metric_vs_horizon_minutes(merged_df)
+            st.divider()
+            st.header("Accuracy & Metrics")
+            st.write(
+                "Calculating metrics requires merging forecasts with observations. This is CPU intensive."
+            )
 
-    fig2 = plot_forecast_metric_vs_horizon_minutes(
-        summary_df,
-        forecaster_names,
-        selected_metric,
-        scale_factor,
-        units,
-        show_sem,
-    )
+            align_t0s_ui = st.checkbox(
+                "Align t0s (Only common t0s across all forecaster are used)", value=True
+            )
 
-    st.plotly_chart(fig2)
+            if st.button("🧮 Calculate Metrics"):
+                with st.spinner("Aligning data and computing metrics..."):
+                    merged_df = pd.merge(
+                        all_forecast_data_df,
+                        all_observations_df,
+                        on="target_timestamp_utc",
+                        suffixes=("", "_observation"),
+                    )
 
-    csv = summary_df.to_csv().encode("utf-8")
-    st.download_button(
-        label="⬇️ Download summary",
-        data=csv,
-        file_name=f"summary_accuracy_{selected_location.location_uuid}_{start_date}_{end_date}.csv",
-        mime="text/csv",
-        help="Download the summary accuracy data as a CSV file.",
-    )
+                    if align_t0s_ui:
+                        merged_df = align_t0(merged_df)
 
-    ### 4. Summary Accuracy Table, with slider to select min and max horizon mins. ###
-    st.subheader("Summary Accuracy Table")
+                    merged_df["error"] = (
+                        merged_df["p50_watts"] - merged_df["value_watts"]
+                    )
+                    merged_df["absolute_error"] = merged_df["error"].abs()
 
-    # add slider to select min and max horizon mins
-    if len(summary_df) > 0:
-        default_min_horizon = int(summary_df["horizon_mins"].min())
-        default_max_horizon = int(summary_df["horizon_mins"].max())
-    else:
-        default_min_horizon = 0
-        default_max_horizon = 1440
-    min_horizon, max_horizon = st.slider(
-        "Select Horizon Mins Range",
-        default_min_horizon,
-        default_max_horizon,
-        (
-            default_min_horizon,
-            default_max_horizon,
-        ),
-        step=30,
-    )
+                    st.session_state.merged_metrics_df = merged_df
 
-    summary_table_df = make_summary_data(
-        merged_df=merged_df,
-        min_horizon=min_horizon,
-        max_horizon=max_horizon,
-        scale_factor=scale_factor,
-        units=units,
-    )
+            # Render Metrics if calculated
+            if st.session_state.merged_metrics_df is not None:
+                merged_df = st.session_state.merged_metrics_df
 
-    st.dataframe(summary_table_df)
+                st.write(metrics)
+                st.subheader("Metric vs Forecast Horizon")
 
-    ### 4. Daily metric plots. ###
-    st.subheader("Daily Metrics Plots")
-    st.write(
-        "Plotted below are the daily MAE for each forecaster. "
-        "This is for all forecast horizons.",
-    )
+                show_sem = False
+                if cfg.metric == "MAE":
+                    show_sem = st.checkbox(
+                        "Show Uncertainty",
+                        value=True,
+                        help="Shows uncertainty bands associated with the MAE using SEM.",
+                    )
 
-    fig3 = plot_forecast_metric_per_day(
-        merged_df=merged_df,
-        forecaster_names=forecaster_names,
-        scale_factor=scale_factor,
-        units=units,
-        selected_metric=selected_metric,
-    )
+                summary_df = make_summary_data_metric_vs_horizon_minutes(merged_df)
 
-    st.plotly_chart(fig3)
+                fig2 = plot_forecast_metric_vs_horizon_minutes(
+                    summary_df,
+                    [f.forecaster_name for f in cfg.forecasters],
+                    cfg.metric,
+                    cfg.scale_factor,
+                    cfg.units,
+                    show_sem,
+                )
+                st.plotly_chart(fig2)
 
-    st.header("Known Issues and TODOs")
+                csv_summary = summary_df.to_csv().encode("utf-8")
+                st.download_button(
+                    label="⬇️ Download Summary",
+                    data=csv_summary,
+                    file_name=f"summary_accuracy_{cfg.location.location_uuid}.csv",
+                    mime="text/csv",
+                )
 
-    st.write("Add more metrics")
-    st.write("Group adjust and non-adjust")
-    st.write("speed up read, use async and more caching")
+                st.subheader("Summary Accuracy Table")
+                if len(summary_df) > 0:
+                    default_min_horizon = int(summary_df["horizon_mins"].min())
+                    default_max_horizon = int(summary_df["horizon_mins"].max())
+                else:
+                    default_min_horizon, default_max_horizon = 0, 1440
+
+                min_horizon, max_horizon = st.slider(
+                    "Select Horizon Mins Range",
+                    default_min_horizon,
+                    default_max_horizon,
+                    (default_min_horizon, default_max_horizon),
+                    step=30,
+                )
+
+                summary_table_df = make_summary_data(
+                    merged_df=merged_df,
+                    min_horizon=min_horizon,
+                    max_horizon=max_horizon,
+                    scale_factor=cfg.scale_factor,
+                    units=cfg.units,
+                )
+                st.dataframe(summary_table_df)
+
+                st.subheader("Daily Metrics Plots")
+                fig3 = plot_forecast_metric_per_day(
+                    merged_df=merged_df,
+                    forecaster_names=[f.forecaster_name for f in cfg.forecasters],
+                    scale_factor=cfg.scale_factor,
+                    units=cfg.units,
+                    selected_metric=cfg.metric,
+                )
+                st.plotly_chart(fig3)
+
+        else:
+            st.info(
+                "Configure your filters in the sidebar and click 'Fetch Forecast & Observations' to begin."
+            )
 
 
 def make_summary_data(
@@ -220,9 +372,10 @@ def make_summary_data(
     units: str,
 ) -> pd.DataFrame:
     """Make summary data table for given min and max horizon mins."""
-    # Reduce my horizon mins
+    # Reduce by horizon mins
     summary_table_df = merged_df[
-        (merged_df["horizon_mins"] >= min_horizon) & (merged_df["horizon_mins"] <= max_horizon)
+        (merged_df["horizon_mins"] >= min_horizon)
+        & (merged_df["horizon_mins"] <= max_horizon)
     ]
 
     capacity_watts_col = "effective_capacity_watts"
@@ -233,37 +386,48 @@ def make_summary_data(
         "value_watts",
         capacity_watts_col,
     ]
-    plevels = [10,25,50,75,90]
+    plevels = [10, 25, 50, 75, 90]
     plevel_metrics = []
     for plevel in plevels:
-        if f'p{plevel}_below' in summary_table_df.columns:
-            plevel_metrics.append(f'p{plevel}_below')
-            value_columns.append(f'p{plevel}_below')
+        if f"p{plevel}_below" in summary_table_df.columns:
+            plevel_metrics.append(f"p{plevel}_below")
+            value_columns.append(f"p{plevel}_below")
     summary_table_df = summary_table_df[["forecaster_name", *value_columns]]
 
-    # group by forecaster full name a
     summary_table_df = summary_table_df.groupby("forecaster_name").mean()
 
-    # scale by units
-    non_plevel_columns = [col for col in summary_table_df.columns if col not in plevel_metrics]
-    summary_table_df[non_plevel_columns] = summary_table_df[non_plevel_columns] / scale_factor
+    # Scale by units
+    non_plevel_columns = [
+        col for col in summary_table_df.columns if col not in plevel_metrics
+    ]
+    summary_table_df[non_plevel_columns] = (
+        summary_table_df[non_plevel_columns] / scale_factor
+    )
     summary_table_df[plevel_metrics] = summary_table_df[plevel_metrics] * 100
     summary_table_df = summary_table_df.rename(
-        {col: f"{col} [{units}]" for col in summary_table_df.columns if col not in plevel_metrics},
+        {
+            col: f"{col} [{units}]"
+            for col in summary_table_df.columns
+            if col not in plevel_metrics
+        },
         axis=1,
     )
     summary_table_df = summary_table_df.rename(
-        {col: f"{col} [%]" for col in summary_table_df.columns if col in plevel_metrics},
+        {
+            col: f"{col} [%]"
+            for col in summary_table_df.columns
+            if col in plevel_metrics
+        },
         axis=1,
     )
 
-    # pivot table, so forecaster_name is columns
+    # Pivot table, so forecaster_name is columns
     summary_table_df = summary_table_df.pivot_table(
         columns=summary_table_df.index,
         values=summary_table_df.columns.tolist(),
     )
 
-    # rename
+    # Rename
     summary_table_df = summary_table_df.rename(
         columns={
             "error": "ME",
@@ -283,7 +447,6 @@ def make_summary_data_metric_vs_horizon_minutes(
     # Get the mean observed generation
     mean_observed_generation = merged_df["value_watts"].mean()
 
-    # mean absolute error by horizonMins and forecasterFullName
     summary_df = (
         merged_df.groupby(["horizon_mins", "forecaster_name"])
         .agg(
@@ -296,26 +459,41 @@ def make_summary_data_metric_vs_horizon_minutes(
     )
 
     summary_df.columns = ["_".join(col).strip() for col in summary_df.columns.values]
-    summary_df.columns = [col[:-1] if col.endswith("_") else col for col in summary_df.columns]
+    summary_df.columns = [
+        col[:-1] if col.endswith("_") else col for col in summary_df.columns
+    ]
 
-    # calculate sem of MAE
+    # Calculate sem of MAE
     summary_df["sem"] = summary_df["absolute_error_std"] / (
         summary_df["absolute_error_count"] ** 0.5
     )
 
-    # TODO more metrics
-
-    summary_df["effective_capacity_watts"] = (
+    summary_df["effective_capacity_watts_observation"] = (
         merged_df.groupby(["horizon_mins", "forecaster_name"])
         .agg({"effective_capacity_watts": "mean"})
         .reset_index()["effective_capacity_watts"]
     )
 
-    # rename absolute_error to MAE
-    summary_df = summary_df.rename(columns={"absolute_error_mean": "MAE", "error_mean": "ME"})
+    summary_df = summary_df.rename(
+        columns={"absolute_error_mean": "MAE", "error_mean": "ME"}
+    )
     summary_df["NMAE (by capacity)"] = (
         summary_df["MAE"] / summary_df["effective_capacity_watts"]
     )
-    summary_df["NMAE (by mean observed generation)"] = summary_df["MAE"] / mean_observed_generation
+    summary_df["NMAE (by mean observed generation)"] = (
+        summary_df["MAE"] / mean_observed_generation
+    )
 
     return summary_df
+
+
+def align_t0(merged_df: pd.DataFrame) -> pd.DataFrame:
+    """Align t0 forecasts for different forecasters."""
+    num_forecasters = merged_df["forecaster_name"].nunique()
+    # Count number of forecasters that have each t0 time
+    counts = merged_df.groupby("initialization_timestamp_utc")[
+        "forecaster_name"
+    ].nunique()
+    # Filter to just those t0s that all forecasters have
+    common_t0s = counts[counts == num_forecasters].index
+    return merged_df[merged_df["initialization_timestamp_utc"].isin(common_t0s)]

--- a/src/dataplatform/forecast/main.py
+++ b/src/dataplatform/forecast/main.py
@@ -12,10 +12,13 @@ from grpclib.client import Channel
 from ocf import dp
 
 from dataplatform.forecast.constant import metrics, observer_names
+from dataplatform.forecast.backend import fetch_observations, fetch_timeseries
 from dataplatform.forecast.plot import (
     plot_forecast_metric_per_day,
     plot_forecast_metric_vs_horizon_minutes,
     plot_forecast_time_series,
+    make_summary_data,
+    make_summary_data_metric_vs_horizon_minutes,
 )
 from dataplatform.forecast.setup import setup_page
 
@@ -34,144 +37,6 @@ def init_session_state():
         st.session_state.fetch_time_stats = ""
     if "locked_params" not in st.session_state:
         st.session_state.locked_params = None
-
-
-async def fetch_timeseries(
-    client: dp.DataPlatformDataServiceStub,
-    location_uuid: str,
-    start_date: datetime.datetime,
-    end_date: datetime.datetime,
-    horizon_mins: int,
-    forecasters: list[dp.Forecaster],
-    init_times_utc: list[datetime.datetime] | None = None,
-) -> pd.DataFrame:
-    """Directly calls GetForecastAsTimeseries for selected models and init times."""
-
-    time_window = dp.TimeWindow(
-        start_timestamp_utc=start_date, end_timestamp_utc=end_date
-    )
-
-    times_to_fetch = init_times_utc if init_times_utc else [None]
-
-    async def fetch_one(
-        forecaster_obj: dp.Forecaster, init_time: datetime.datetime | None
-    ):
-        req = dp.GetForecastAsTimeseriesRequest(
-            location_uuid=location_uuid,
-            energy_source=dp.EnergySource.SOLAR,
-            horizon_mins=horizon_mins,
-            time_window=time_window,
-            forecaster=forecaster_obj,
-            initialization_timestamp_utc=init_time,
-        )
-
-        try:
-            resp = await client.get_forecast_as_timeseries(req)
-            rows = []
-            for val in resp.values:
-                row = {
-                    "target_timestamp_utc": val.target_timestamp_utc,
-                    "initialization_timestamp_utc": val.initialization_timestamp_utc,
-                    "created_timestamp_utc": val.created_timestamp_utc,
-                    "effective_capacity_watts": val.effective_capacity_watts,
-                    "forecaster_name": forecaster_obj.forecaster_name,
-                    "location_uuid": resp.location_uuid,
-                    "horizon_mins": (
-                        val.target_timestamp_utc - val.initialization_timestamp_utc
-                    ).total_seconds()
-                    // 60,
-                    "p50_watts": int(
-                        val.p50_value_fraction * val.effective_capacity_watts
-                    ),
-                }
-
-                if val.other_statistics_fractions:
-                    row.update(
-                        {
-                            f"{k}_watts": int(v * val.effective_capacity_watts)
-                            for k, v in val.other_statistics_fractions.items()
-                        }
-                    )
-                rows.append(row)
-
-            return rows
-        except Exception as e:
-            time_str = init_time.isoformat() if init_time else "Latest"
-            st.error(
-                f"Failed to fetch {forecaster_obj.forecaster_name} at {time_str}: {e}"
-            )
-            return []
-
-    tasks = [fetch_one(f, t) for f in forecasters for t in times_to_fetch]
-
-    results = await asyncio.gather(*tasks)
-    all_rows = [item for sublist in results for item in sublist]
-
-    df = pd.DataFrame(all_rows)
-    if not df.empty:
-        df["target_timestamp_utc"] = pd.to_datetime(df["target_timestamp_utc"])
-        if "initialization_timestamp_utc" in df.columns:
-            df["initialization_timestamp_utc"] = pd.to_datetime(
-                df["initialization_timestamp_utc"]
-            )
-
-    return df
-
-
-async def fetch_observations(
-    client: dp.DataPlatformDataServiceStub,
-    location_uuid: str,
-    start_date: datetime.datetime,
-    end_date: datetime.datetime,
-    observers: list[str],
-    energy_source: dp.EnergySource = dp.EnergySource.SOLAR,
-) -> pd.DataFrame:
-    """Directly calls GetObservationsAsTimeseries for selected observers."""
-
-    time_window = dp.TimeWindow(
-        start_timestamp_utc=start_date, end_timestamp_utc=end_date
-    )
-
-    # Run requests concurrently for all selected observers
-    async def fetch_one(obs_name: str):
-        req = dp.GetObservationsAsTimeseriesRequest(
-            location_uuid=location_uuid,
-            observer_name=obs_name,
-            energy_source=energy_source,
-            time_window=time_window,
-        )
-
-        try:
-            resp = await client.get_observations_as_timeseries(req)
-            rows = []
-            for val in resp.values:
-                rows.append(
-                    {
-                        "target_timestamp_utc": val.timestamp_utc,
-                        "value_fraction": val.value_fraction,
-                        "effective_capacity_watts": val.effective_capacity_watts,
-                        "observer_name": obs_name,
-                        "location_uuid": resp.location_uuid,
-                        "value_watts": int(
-                            val.value_fraction * val.effective_capacity_watts
-                        ),
-                    }
-                )
-            return rows
-        except Exception as e:
-            st.error(f"Failed to fetch observations for {obs_name}: {e}")
-            return []
-
-    results = await asyncio.gather(*[fetch_one(obs) for obs in observers])
-    all_rows = [item for sublist in results for item in sublist]
-
-    df = pd.DataFrame(all_rows)
-
-    if not df.empty:
-        df["target_timestamp_utc"] = pd.to_datetime(df["target_timestamp_utc"])
-
-    return df
-
 
 def dp_forecast_page() -> None:
     """Wrapper function that is not async to call the main async function."""
@@ -287,7 +152,14 @@ async def async_dp_forecast_page() -> None:
                     )
 
                     if align_t0s_ui:
-                        merged_df = align_t0(merged_df)
+                        num_forecasters = merged_df["forecaster_name"].nunique()
+                        # Count number of forecasters that have each t0 time
+                        counts = merged_df.groupby("initialization_timestamp_utc")[
+                            "forecaster_name"
+                        ].nunique()
+                        # Filter to just those t0s that all forecasters have
+                        common_t0s = counts[counts == num_forecasters].index
+                        merged_df = merged_df[merged_df["initialization_timestamp_utc"].isin(common_t0s)]
 
                     merged_df["error"] = (
                         merged_df["p50_watts"] - merged_df["value_watts"]
@@ -304,7 +176,7 @@ async def async_dp_forecast_page() -> None:
                 st.subheader("Metric vs Forecast Horizon")
 
                 show_sem = False
-                if cfg.metric == "MAE":
+                if cfg.metric == "MAE": # This is not locked on purpose
                     show_sem = st.checkbox(
                         "Show Uncertainty",
                         value=True,
@@ -315,8 +187,8 @@ async def async_dp_forecast_page() -> None:
 
                 fig2 = plot_forecast_metric_vs_horizon_minutes(
                     summary_df,
-                    [f.forecaster_name for f in lcfg.forecasters],
-                    lcfg.metric,
+                    list({f.forecaster_name for f in lcfg.forecasters}),
+                    cfg.metric, # This is not locked on purpose
                     lcfg.scale_factor,
                     lcfg.units,
                     show_sem,
@@ -361,7 +233,7 @@ async def async_dp_forecast_page() -> None:
                     forecaster_names=list({f.forecaster_name for f in lcfg.forecasters}),
                     scale_factor=lcfg.scale_factor,
                     units=lcfg.units,
-                    selected_metric=lcfg.metric,
+                    selected_metric=cfg.metric, # This is also not locked on purpose
                 )
                 st.plotly_chart(fig3)
 
@@ -370,137 +242,3 @@ async def async_dp_forecast_page() -> None:
                 "Configure your filters in the sidebar and click 'Fetch Forecast & Observations' to begin."
             )
 
-
-def make_summary_data(
-    merged_df: pd.DataFrame,
-    min_horizon: int,
-    max_horizon: int,
-    scale_factor: float,
-    units: str,
-) -> pd.DataFrame:
-    """Make summary data table for given min and max horizon mins."""
-    # Reduce by horizon mins
-    summary_table_df = merged_df[
-        (merged_df["horizon_mins"] >= min_horizon)
-        & (merged_df["horizon_mins"] <= max_horizon)
-    ]
-
-    capacity_watts_col = "effective_capacity_watts"
-
-    value_columns = [
-        "error",
-        "absolute_error",
-        "value_watts",
-        capacity_watts_col,
-    ]
-    plevels = [10, 25, 50, 75, 90]
-    plevel_metrics = []
-    for plevel in plevels:
-        if f"p{plevel}_below" in summary_table_df.columns:
-            plevel_metrics.append(f"p{plevel}_below")
-            value_columns.append(f"p{plevel}_below")
-    summary_table_df = summary_table_df[["forecaster_name", *value_columns]]
-
-    summary_table_df = summary_table_df.groupby("forecaster_name").mean()
-
-    # Scale by units
-    non_plevel_columns = [
-        col for col in summary_table_df.columns if col not in plevel_metrics
-    ]
-    summary_table_df[non_plevel_columns] = (
-        summary_table_df[non_plevel_columns] / scale_factor
-    )
-    summary_table_df[plevel_metrics] = summary_table_df[plevel_metrics] * 100
-    summary_table_df = summary_table_df.rename(
-        {
-            col: f"{col} [{units}]"
-            for col in summary_table_df.columns
-            if col not in plevel_metrics
-        },
-        axis=1,
-    )
-    summary_table_df = summary_table_df.rename(
-        {
-            col: f"{col} [%]"
-            for col in summary_table_df.columns
-            if col in plevel_metrics
-        },
-        axis=1,
-    )
-
-    # Pivot table, so forecaster_name is columns
-    summary_table_df = summary_table_df.pivot_table(
-        columns=summary_table_df.index,
-        values=summary_table_df.columns.tolist(),
-    )
-
-    # Rename
-    summary_table_df = summary_table_df.rename(
-        columns={
-            "error": "ME",
-            "absolute_error": "MAE",
-            capacity_watts_col: "Mean Capacity",
-            "value_watts": "Mean Observed Generation",
-        },
-    )
-
-    return summary_table_df
-
-
-def make_summary_data_metric_vs_horizon_minutes(
-    merged_df: pd.DataFrame,
-) -> pd.DataFrame:
-    """Make summary data for forecast metric vs horizon minutes."""
-    # Get the mean observed generation
-    mean_observed_generation = merged_df["value_watts"].mean()
-
-    summary_df = (
-        merged_df.groupby(["horizon_mins", "forecaster_name"])
-        .agg(
-            {
-                "absolute_error": ["mean", "std", "count"],
-                "error": "mean",
-            },
-        )
-        .reset_index()
-    )
-
-    summary_df.columns = ["_".join(col).strip() for col in summary_df.columns.values]
-    summary_df.columns = [
-        col[:-1] if col.endswith("_") else col for col in summary_df.columns
-    ]
-
-    # Calculate sem of MAE
-    summary_df["sem"] = summary_df["absolute_error_std"] / (
-        summary_df["absolute_error_count"] ** 0.5
-    )
-
-    summary_df["effective_capacity_watts_observation"] = (
-        merged_df.groupby(["horizon_mins", "forecaster_name"])
-        .agg({"effective_capacity_watts": "mean"})
-        .reset_index()["effective_capacity_watts"]
-    )
-
-    summary_df = summary_df.rename(
-        columns={"absolute_error_mean": "MAE", "error_mean": "ME"}
-    )
-    summary_df["NMAE (by capacity)"] = (
-        summary_df["MAE"] / summary_df["effective_capacity_watts"]
-    )
-    summary_df["NMAE (by mean observed generation)"] = (
-        summary_df["MAE"] / mean_observed_generation
-    )
-
-    return summary_df
-
-
-def align_t0(merged_df: pd.DataFrame) -> pd.DataFrame:
-    """Align t0 forecasts for different forecasters."""
-    num_forecasters = merged_df["forecaster_name"].nunique()
-    # Count number of forecasters that have each t0 time
-    counts = merged_df.groupby("initialization_timestamp_utc")[
-        "forecaster_name"
-    ].nunique()
-    # Filter to just those t0s that all forecasters have
-    common_t0s = counts[counts == num_forecasters].index
-    return merged_df[merged_df["initialization_timestamp_utc"].isin(common_t0s)]

--- a/src/dataplatform/forecast/main.py
+++ b/src/dataplatform/forecast/main.py
@@ -1,8 +1,8 @@
 """Data Platform Forecast Streamlit Page Main Code."""
-import dataclasses
 
 import asyncio
 import os
+import dataclasses
 import datetime
 
 import pandas as pd
@@ -219,7 +219,9 @@ async def async_dp_forecast_page() -> None:
                 st.session_state.forecast_df = df_forecast
                 st.session_state.observations_df = df_obs
                 st.session_state.merged_metrics_df = None  # Reset metrics on new fetch
-                st.session_state.locked_config = dataclasses.replace(cfg) # Copy the config to a new instance
+                st.session_state.locked_config = dataclasses.replace(
+                    cfg
+                )  # Copy the config to a new instance
 
                 st.session_state.fetch_time_stats = (
                     f"Fetched `{len(df_forecast)}` forecast rows "

--- a/src/dataplatform/forecast/main.py
+++ b/src/dataplatform/forecast/main.py
@@ -1,4 +1,5 @@
 """Data Platform Forecast Streamlit Page Main Code."""
+import dataclasses
 
 import asyncio
 import os
@@ -31,6 +32,8 @@ def init_session_state():
         st.session_state.merged_metrics_df = None
     if "fetch_time_stats" not in st.session_state:
         st.session_state.fetch_time_stats = ""
+    if "locked_params" not in st.session_state:
+        st.session_state.locked_params = None
 
 
 async def fetch_timeseries(
@@ -216,6 +219,7 @@ async def async_dp_forecast_page() -> None:
                 st.session_state.forecast_df = df_forecast
                 st.session_state.observations_df = df_obs
                 st.session_state.merged_metrics_df = None  # Reset metrics on new fetch
+                st.session_state.locked_config = dataclasses.replace(cfg) # Copy the config to a new instance
 
                 st.session_state.fetch_time_stats = (
                     f"Fetched `{len(df_forecast)}` forecast rows "
@@ -245,18 +249,19 @@ async def async_dp_forecast_page() -> None:
             st.header("Time Series Plot")
             show_probabilistic = st.checkbox("Show Probabilistic Forecasts", value=True)
 
+            lcfg = st.session_state.locked_config
             fig = plot_forecast_time_series(
                 all_forecast_data_df=all_forecast_data_df,
                 all_observations_df=all_observations_df,
-                forecaster_names=[f.forecaster_name for f in cfg.forecasters],
+                forecaster_names=[f.forecaster_name for f in lcfg.forecasters],
                 observer_names=observer_names,
-                scale_factor=cfg.scale_factor,
-                units=cfg.units,
-                selected_forecast_type=cfg.forecast_type,
-                selected_forecast_horizon=cfg.forecast_horizon,
-                selected_t0s=cfg.t0s,
+                scale_factor=lcfg.scale_factor,
+                units=lcfg.units,
+                selected_forecast_type=lcfg.forecast_type,
+                selected_forecast_horizon=lcfg.forecast_horizon,
+                selected_t0s=lcfg.t0s,
                 show_probabilistic=show_probabilistic,
-                strict_horizon_filtering=cfg.strict_horizon_filtering,
+                strict_horizon_filtering=lcfg.strict_horizon_filtering,
             )
             st.plotly_chart(fig)
 
@@ -308,10 +313,10 @@ async def async_dp_forecast_page() -> None:
 
                 fig2 = plot_forecast_metric_vs_horizon_minutes(
                     summary_df,
-                    [f.forecaster_name for f in cfg.forecasters],
-                    cfg.metric,
-                    cfg.scale_factor,
-                    cfg.units,
+                    [f.forecaster_name for f in lcfg.forecasters],
+                    lcfg.metric,
+                    lcfg.scale_factor,
+                    lcfg.units,
                     show_sem,
                 )
                 st.plotly_chart(fig2)
@@ -343,18 +348,18 @@ async def async_dp_forecast_page() -> None:
                     merged_df=merged_df,
                     min_horizon=min_horizon,
                     max_horizon=max_horizon,
-                    scale_factor=cfg.scale_factor,
-                    units=cfg.units,
+                    scale_factor=lcfg.scale_factor,
+                    units=lcfg.units,
                 )
                 st.dataframe(summary_table_df)
 
                 st.subheader("Daily Metrics Plots")
                 fig3 = plot_forecast_metric_per_day(
                     merged_df=merged_df,
-                    forecaster_names=[f.forecaster_name for f in cfg.forecasters],
-                    scale_factor=cfg.scale_factor,
-                    units=cfg.units,
-                    selected_metric=cfg.metric,
+                    forecaster_names=[f.forecaster_name for f in lcfg.forecasters],
+                    scale_factor=lcfg.scale_factor,
+                    units=lcfg.units,
+                    selected_metric=lcfg.metric,
                 )
                 st.plotly_chart(fig3)
 

--- a/src/dataplatform/forecast/main.py
+++ b/src/dataplatform/forecast/main.py
@@ -255,7 +255,7 @@ async def async_dp_forecast_page() -> None:
             fig = plot_forecast_time_series(
                 all_forecast_data_df=all_forecast_data_df,
                 all_observations_df=all_observations_df,
-                forecaster_names=[f.forecaster_name for f in lcfg.forecasters],
+                forecaster_names=list({f.forecaster_name for f in lcfg.forecasters}),
                 observer_names=observer_names,
                 scale_factor=lcfg.scale_factor,
                 units=lcfg.units,
@@ -358,7 +358,7 @@ async def async_dp_forecast_page() -> None:
                 st.subheader("Daily Metrics Plots")
                 fig3 = plot_forecast_metric_per_day(
                     merged_df=merged_df,
-                    forecaster_names=[f.forecaster_name for f in lcfg.forecasters],
+                    forecaster_names=list({f.forecaster_name for f in lcfg.forecasters}),
                     scale_factor=lcfg.scale_factor,
                     units=lcfg.units,
                     selected_metric=lcfg.metric,

--- a/src/dataplatform/forecast/plot.py
+++ b/src/dataplatform/forecast/plot.py
@@ -104,7 +104,7 @@ def plot_forecast_time_series(
         ]
     elif selected_forecast_type == "t0":
         current_forecast_df = all_forecast_data_df[
-            all_forecast_data_df["init_timestamp"].isin(selected_t0s)
+            all_forecast_data_df["initialization_timestamp_utc"].isin(selected_t0s)
         ]
 
     # plot the results
@@ -122,7 +122,7 @@ def plot_forecast_time_series(
 
         fig.add_trace(
             go.Scatter(
-                x=obs_df["timestamp_utc"],
+                x=obs_df["target_timestamp_utc"],
                 y=obs_df["value_watts"] / scale_factor,
                 mode="lines",
                 name=observer_name,
@@ -145,7 +145,7 @@ def plot_forecast_time_series(
             )
         elif selected_forecast_type == "t0":
             for _, t0 in enumerate(selected_t0s):
-                forecaster_with_t0_df = forecaster_df[forecaster_df["init_timestamp"] == t0]
+                forecaster_with_t0_df = forecaster_df[forecaster_df["initialization_timestamp_utc"] == t0]
                 forecaster_name_wth_t0 = f"{forecaster_name} | t0: {t0}"
                 fig = make_time_series_trace(
                     fig,
@@ -236,7 +236,7 @@ def plot_forecast_metric_per_day(
 ) -> go.Figure:
     """Plot forecast metric per day."""
     daily_plots_df = merged_df
-    daily_plots_df["date_utc"] = daily_plots_df["timestamp_utc"].dt.date
+    daily_plots_df["date_utc"] = daily_plots_df["target_timestamp_utc"].dt.date
 
     # group by forecaster name and date
     daily_metrics_df = (

--- a/src/dataplatform/forecast/plot.py
+++ b/src/dataplatform/forecast/plot.py
@@ -271,3 +271,126 @@ def plot_forecast_metric_per_day(
         fig3.update_yaxes(range=[0, None])
 
     return fig3
+
+def make_summary_data(
+    merged_df: pd.DataFrame,
+    min_horizon: int,
+    max_horizon: int,
+    scale_factor: float,
+    units: str,
+) -> pd.DataFrame:
+    """Make summary data table for given min and max horizon mins."""
+    # Reduce by horizon mins
+    summary_table_df = merged_df[
+        (merged_df["horizon_mins"] >= min_horizon)
+        & (merged_df["horizon_mins"] <= max_horizon)
+    ]
+
+    capacity_watts_col = "effective_capacity_watts_observation"
+
+    value_columns = [
+        "error",
+        "absolute_error",
+        "value_watts",
+        capacity_watts_col,
+    ]
+    plevels = [10, 25, 50, 75, 90]
+    plevel_metrics = []
+    for plevel in plevels:
+        if f"p{plevel}_below" in summary_table_df.columns:
+            plevel_metrics.append(f"p{plevel}_below")
+            value_columns.append(f"p{plevel}_below")
+    summary_table_df = summary_table_df[["forecaster_name", *value_columns]]
+
+    summary_table_df = summary_table_df.groupby("forecaster_name").mean()
+
+    # Scale by units
+    non_plevel_columns = [
+        col for col in summary_table_df.columns if col not in plevel_metrics
+    ]
+    summary_table_df[non_plevel_columns] = (
+        summary_table_df[non_plevel_columns] / scale_factor
+    )
+    summary_table_df[plevel_metrics] = summary_table_df[plevel_metrics] * 100
+    summary_table_df = summary_table_df.rename(
+        {
+            col: f"{col} [{units}]"
+            for col in summary_table_df.columns
+            if col not in plevel_metrics
+        },
+        axis=1,
+    )
+    summary_table_df = summary_table_df.rename(
+        {
+            col: f"{col} [%]"
+            for col in summary_table_df.columns
+            if col in plevel_metrics
+        },
+        axis=1,
+    )
+
+    # Pivot table, so forecaster_name is columns
+    summary_table_df = summary_table_df.pivot_table(
+        columns=summary_table_df.index,
+        values=summary_table_df.columns.tolist(),
+    )
+
+    # Rename
+    summary_table_df = summary_table_df.rename(
+        columns={
+            "error": "ME",
+            "absolute_error": "MAE",
+            capacity_watts_col: "Mean Capacity",
+            "value_watts": "Mean Observed Generation",
+        },
+    )
+
+    return summary_table_df
+
+
+def make_summary_data_metric_vs_horizon_minutes(
+    merged_df: pd.DataFrame,
+) -> pd.DataFrame:
+    """Make summary data for forecast metric vs horizon minutes."""
+    # Get the mean observed generation
+    mean_observed_generation = merged_df["value_watts"].mean()
+
+    summary_df = (
+        merged_df.groupby(["horizon_mins", "forecaster_name"])
+        .agg(
+            {
+                "absolute_error": ["mean", "std", "count"],
+                "error": "mean",
+            },
+        )
+        .reset_index()
+    )
+
+    summary_df.columns = ["_".join(col).strip() for col in summary_df.columns.values]
+    summary_df.columns = [
+        col[:-1] if col.endswith("_") else col for col in summary_df.columns
+    ]
+
+    # Calculate sem of MAE
+    summary_df["sem"] = summary_df["absolute_error_std"] / (
+        summary_df["absolute_error_count"] ** 0.5
+    )
+
+    summary_df["effective_capacity_watts_observation"] = (
+        merged_df.groupby(["horizon_mins", "forecaster_name"])
+        .agg({"effective_capacity_watts_observation": "mean"})
+        .reset_index()["effective_capacity_watts_observation"]
+    )
+
+    summary_df = summary_df.rename(
+        columns={"absolute_error_mean": "MAE", "error_mean": "ME"}
+    )
+    summary_df["NMAE (by capacity)"] = (
+        summary_df["MAE"] / summary_df["effective_capacity_watts_observation"]
+    )
+    summary_df["NMAE (by mean observed generation)"] = (
+        summary_df["MAE"] / mean_observed_generation
+    )
+
+    return summary_df
+

--- a/src/dataplatform/forecast/setup.py
+++ b/src/dataplatform/forecast/setup.py
@@ -1,6 +1,7 @@
 """Setup Forecast Streamlit Page."""
 
 from datetime import UTC, datetime, timedelta
+import dataclasses
 
 import pandas as pd
 import streamlit as st
@@ -14,30 +15,31 @@ from dataplatform.forecast.constant import cache_seconds, metrics
 @cached(ttl=cache_seconds, cache=Cache.MEMORY, key_builder=key_builder_remove_client)
 async def get_location_names(
     client: dp.DataPlatformDataServiceStub,
-    location_type: dp.LocationType,
 ) -> dict:
-    """Get location names for a given location type."""
-    # List Location
-    list_locations_request = dp.ListLocationsRequest(location_type_filter=location_type)
+    """Get location names."""
+    list_locations_request = dp.ListLocationsRequest()
     list_locations_response = await client.list_locations(list_locations_request)
     all_locations = list_locations_response.locations
 
     location_names = {loc.location_name: loc for loc in all_locations}
-    if location_type == dp.LocationType.GSP:
-        location_names = {
-            f"{int(loc.metadata.fields['gsp_id'].number_value)}:{loc.location_name}": loc
-            for loc in all_locations
-        }
-        # sort by gsp id
-        location_names = dict(
-            sorted(location_names.items(), key=lambda item: int(item[0].split(":")[0])),
+    location_names = dict(
+        sorted(
+            location_names.items(),
+            key=lambda item: (
+                item[1].metadata.fields["gsp_id"].number_value
+                if "gsp_id" in item[1].metadata.fields
+                else float("inf")
+            ),
         )
+    )
 
     return location_names
 
 
 @cached(ttl=cache_seconds, cache=Cache.MEMORY, key_builder=key_builder_remove_client)
-async def get_forecasters(client: dp.DataPlatformDataServiceStub) -> list[dp.Forecaster]:
+async def get_forecasters(
+    client: dp.DataPlatformDataServiceStub,
+) -> list[dp.Forecaster]:
     """Get all forecasters."""
     get_forecasters_request = dp.ListForecastersRequest()
     get_forecasters_response = await client.list_forecasters(get_forecasters_request)
@@ -45,22 +47,24 @@ async def get_forecasters(client: dp.DataPlatformDataServiceStub) -> list[dp.For
     return forecasters
 
 
-async def setup_page(client: dp.DataPlatformDataServiceStub) -> dict:
+@dataclasses.dataclass
+class PageConfig:
+    location: dp.ListLocationsResponseLocationSummary
+    forecasters: list[dp.Forecaster]
+    start_date: datetime
+    end_date: datetime
+    forecast_type: str
+    scale_factor: float
+    metric: str
+    forecast_horizon: int
+    t0s: list[datetime] | None
+    units: str
+    strict_horizon_filtering: bool
+
+
+async def setup_page(client: dp.DataPlatformDataServiceStub) -> PageConfig:
     """Setup the Streamlit page with sidebar options."""
-    # Select Country
-    st.sidebar.selectbox("TODO Select a Country", ["UK", "NL"], index=0)
-
-    # Select Location Type
-    location_types = [
-        dp.LocationType.NATION,
-        dp.LocationType.STATE,
-        dp.LocationType.GSP,
-        dp.LocationType.SITE,
-    ]
-    location_type = st.sidebar.selectbox("Select a Location Type", location_types, index=0)
-
-    # select locations
-    location_names = await get_location_names(client, location_type)
+    location_names = await get_location_names(client)
     selected_location_name = st.sidebar.selectbox(
         "Select a Location",
         location_names.keys(),
@@ -68,42 +72,49 @@ async def setup_page(client: dp.DataPlatformDataServiceStub) -> dict:
     )
     selected_location = location_names[selected_location_name]
 
-    # get models
     forecasters = await get_forecasters(client)
-    forecaster_names = sorted({forecaster.forecaster_name for forecaster in forecasters})
-    default_index = forecaster_names.index("pvnet_v2") if "pvnet_v2" in forecaster_names else 0
+    forecaster_names = sorted(
+        {forecaster.forecaster_name for forecaster in forecasters}
+    )
+    default_index = (
+        forecaster_names.index("pvnet_v2") if "pvnet_v2" in forecaster_names else 0
+    )
     selected_forecaster_name = st.sidebar.multiselect(
         "Select a Forecaster",
         forecaster_names,
         default=forecaster_names[default_index],
     )
+
     selected_forecasters = [
         forecaster
         for forecaster in forecasters
         if forecaster.forecaster_name in selected_forecaster_name
     ]
 
-    # select start and end date
     start_date = st.sidebar.date_input(
         "Start date:",
-        datetime.now(tz=UTC).date() - timedelta(days=7),
+        datetime.now(tz=UTC).date() - timedelta(days=2),
     )
-    end_date = st.sidebar.date_input("End date:", datetime.now(tz=UTC).date() + timedelta(days=3))
+    end_date = st.sidebar.date_input(
+        "End date:", datetime.now(tz=UTC).date() + timedelta(days=2)
+    )
     start_date = datetime.combine(start_date, datetime.min.time()).replace(tzinfo=UTC)
-    end_date = datetime.combine(end_date, datetime.min.time()).replace(tzinfo=UTC) - timedelta(
+    end_date = datetime.combine(end_date, datetime.min.time()).replace(
+        tzinfo=UTC
+    ) - timedelta(
         seconds=1,
     )
 
-    # select forecast type
     selected_forecast_type = st.sidebar.selectbox(
         "Select a Forecast Type",
         ["Current", "Horizon", "t0"],
         index=0,
     )
 
-    selected_forecast_horizon = None
+    selected_forecast_horizon = 0
     strict_horizon_filtering = False
     selected_t0s = None
+
     if selected_forecast_type == "Horizon":
         selected_forecast_horizon = st.sidebar.selectbox(
             "Select a Forecast Horizon",
@@ -116,10 +127,13 @@ async def setup_page(client: dp.DataPlatformDataServiceStub) -> dict:
             help="Only show forecasts that exactly match the selected horizon, "
             "if not, we use any forecast horizon greater or equal than",
         )
+
     if selected_forecast_type == "t0":
-        # make datetimes every 30 minutes from start_date to end_date
+        # Make datetimes every 30 minutes from start_date to end_date
         all_t0s = (
-            pd.date_range(start=start_date, end=end_date, freq="30min").to_pydatetime().tolist()
+            pd.date_range(start=start_date, end=end_date, freq="30min")
+            .to_pydatetime()
+            .tolist()
         )
 
         selected_t0s = st.sidebar.multiselect(
@@ -128,25 +142,25 @@ async def setup_page(client: dp.DataPlatformDataServiceStub) -> dict:
             default=all_t0s[: min(5, len(all_t0s))],
         )
 
-    # select units
     default_unit_index = 2  # MW
-    units = st.sidebar.selectbox("Select Units", ["W", "kW", "MW", "GW"], index=default_unit_index)
+    units = st.sidebar.selectbox(
+        "Select Units", ["W", "kW", "MW", "GW"], index=default_unit_index
+    )
     scale_factors = {"W": 1, "kW": 1e3, "MW": 1e6, "GW": 1e9}
     scale_factor = scale_factors[units]
 
-    selected_metric = st.sidebar.selectbox("Select a Metrics", metrics.keys(), index=0)
+    selected_metric = st.sidebar.selectbox("Select Metrics", metrics.keys(), index=0)
 
-    return {
-        "selected_location": selected_location,
-        "selected_forecasters": selected_forecasters,
-        "start_date": start_date,
-        "end_date": end_date,
-        "selected_forecast_type": selected_forecast_type,
-        "scale_factor": scale_factor,
-        "selected_metric": selected_metric,
-        "forecaster_names": forecaster_names,
-        "selected_forecast_horizon": selected_forecast_horizon,
-        "selected_t0s": selected_t0s,
-        "units": units,
-        "strict_horizon_filtering": strict_horizon_filtering,
-    }
+    return PageConfig(
+        location=selected_location,
+        forecasters=selected_forecasters,
+        start_date=start_date,
+        end_date=end_date,
+        forecast_type=selected_forecast_type,
+        scale_factor=scale_factor,
+        metric=selected_metric,
+        forecast_horizon=selected_forecast_horizon,
+        t0s=selected_t0s,
+        units=units,
+        strict_horizon_filtering=strict_horizon_filtering,
+    )

--- a/src/dataplatform/forecast/setup.py
+++ b/src/dataplatform/forecast/setup.py
@@ -1,6 +1,6 @@
 """Setup Forecast Streamlit Page."""
 
-from datetime import UTC, datetime, timedelta
+import datetime as dt
 import dataclasses
 
 import pandas as pd
@@ -51,13 +51,13 @@ async def get_forecasters(
 class PageConfig:
     location: dp.ListLocationsResponseLocationSummary
     forecasters: list[dp.Forecaster]
-    start_date: datetime
-    end_date: datetime
+    start_date: dt.datetime
+    end_date: dt.datetime
     forecast_type: str
     scale_factor: float
     metric: str
     forecast_horizon: int
-    t0s: list[datetime] | None
+    t0s: list[dt.datetime] | None
     units: str
     strict_horizon_filtering: bool
 
@@ -66,7 +66,7 @@ async def setup_page(client: dp.DataPlatformDataServiceStub) -> PageConfig:
     """Setup the Streamlit page with sidebar options."""
     location_names = await get_location_names(client)
     selected_location_name = st.sidebar.selectbox(
-        "Select a Location",
+        "Location",
         location_names.keys(),
         index=0,
     )
@@ -80,7 +80,7 @@ async def setup_page(client: dp.DataPlatformDataServiceStub) -> PageConfig:
         forecaster_names.index("pvnet_v2") if "pvnet_v2" in forecaster_names else 0
     )
     selected_forecaster_name = st.sidebar.multiselect(
-        "Select a Forecaster",
+        "Forecaster",
         forecaster_names,
         default=forecaster_names[default_index],
     )
@@ -91,22 +91,23 @@ async def setup_page(client: dp.DataPlatformDataServiceStub) -> PageConfig:
         if forecaster.forecaster_name in selected_forecaster_name
     ]
 
-    start_date = st.sidebar.date_input(
-        "Start date:",
-        datetime.now(tz=UTC).date() - timedelta(days=2),
+    now = dt.datetime.now(tz=dt.UTC).replace(hour=0, minute=0, second=0, microsecond=0)
+    window = st.sidebar.date_input(
+        "Time window",
+        (
+            (now - dt.timedelta(days=1)).date(),
+            (now + dt.timedelta(days=2)).date(),
+        ),
+        (now - dt.timedelta(days=365)).date(),
+        (now + dt.timedelta(days=365)).date(),
     )
-    end_date = st.sidebar.date_input(
-        "End date:", datetime.now(tz=UTC).date() + timedelta(days=2)
-    )
-    start_date = datetime.combine(start_date, datetime.min.time()).replace(tzinfo=UTC)
-    end_date = datetime.combine(end_date, datetime.min.time()).replace(
-        tzinfo=UTC
-    ) - timedelta(
-        seconds=1,
-    )
+    start_date = dt.datetime.combine(window[0], now.time()).replace(tzinfo=dt.UTC)
+    end_date = (start_date + dt.timedelta(days=2)).replace(tzinfo=dt.UTC) - dt.timedelta(seconds=1)
+    if len(window) == 2:
+        end_date = dt.datetime.combine(window[1], now.time()).replace(tzinfo=dt.UTC) - dt.timedelta(seconds=1)
 
     selected_forecast_type = st.sidebar.selectbox(
-        "Select a Forecast Type",
+        "Forecast Type",
         ["Current", "Horizon", "t0"],
         index=0,
     )
@@ -117,12 +118,12 @@ async def setup_page(client: dp.DataPlatformDataServiceStub) -> PageConfig:
 
     if selected_forecast_type == "Horizon":
         selected_forecast_horizon = st.sidebar.selectbox(
-            "Select a Forecast Horizon",
+            "Minimum Forecast Horizon (minutes)",
             list(range(0, 36 * 60, 30)),
             index=3,
         )
         strict_horizon_filtering = st.sidebar.checkbox(
-            "Strict Horizon Filtering",
+            "Exact horizons only",
             value=False,
             help="Only show forecasts that exactly match the selected horizon, "
             "if not, we use any forecast horizon greater or equal than",
@@ -135,21 +136,23 @@ async def setup_page(client: dp.DataPlatformDataServiceStub) -> PageConfig:
             .to_pydatetime()
             .tolist()
         )
+        t0_dict = {t.strftime("%Y-%m-%d %H:%M"): t for t in all_t0s}
 
-        selected_t0s = st.sidebar.multiselect(
-            "Select t0s",
-            all_t0s,
-            default=all_t0s[: min(5, len(all_t0s))],
+        selected_t0_strs = st.sidebar.multiselect(
+            "Desired t0s",
+            options=list(t0_dict.keys()),
+            default=list(t0_dict.keys())[:5],
         )
+        selected_t0s = [t0_dict[t_str] for t_str in selected_t0_strs]
 
     default_unit_index = 2  # MW
     units = st.sidebar.selectbox(
-        "Select Units", ["W", "kW", "MW", "GW"], index=default_unit_index
+        "Units", ["W", "kW", "MW", "GW"], index=default_unit_index
     )
     scale_factors = {"W": 1, "kW": 1e3, "MW": 1e6, "GW": 1e9}
     scale_factor = scale_factors[units]
 
-    selected_metric = st.sidebar.selectbox("Select Metrics", metrics.keys(), index=0)
+    selected_metric = st.sidebar.selectbox("Desired Metric", metrics.keys(), index=0)
 
     return PageConfig(
         location=selected_location,

--- a/src/main.py
+++ b/src/main.py
@@ -25,16 +25,33 @@ def main_page():
 
 
 if check_password():
-    pg = st.navigation([
-        st.Page(main_page, title="🏠 Home", default=True),
-        st.Page(status_page, title="🚦 Status"),
-        st.Page(pvsite_forecast_page, title="📉 Site Forecast"),
-        st.Page(dp_forecast_page, title="📉 DP Forecast"),
-        st.Page(sites_toolbox_page, title="🛠️ Sites Toolbox"),
-        st.Page(user_page, title="👥 API Users"),
-        st.Page(nwp_page, title="🌤️ NWP"),
-        st.Page(satellite_page, title="🛰️ Satellite"),
-        st.Page(cloudcasting_page, title="☁️ Cloudcasting"),
-        st.Page(batch_page, title="👀 Batch Visualisation Page"),
-        st.Page(dataplatform_toolbox_page, title="🛠️ Data Platform Toolbox")], position="top")
+    pg = st.navigation({
+        "Home": [
+            st.Page(main_page, title="🏠 Home", default=True),
+            st.Page(status_page, title="Status"),
+            st.Page(user_page, title="API Users"),
+        ],
+        "Data Platform": [
+            st.Page(dp_forecast_page, title="Data Platform Forecast"),
+            st.Page(dataplatform_toolbox_page, title="Data Platform Toolbox"),
+        ],
+        "Sites": [
+            st.Page(pvsite_forecast_page, title="Site Forecast"),
+            st.Page(sites_toolbox_page, title="Sites Toolbox"),
+        ],
+        "Input Data": [
+            st.Page(nwp_page, title="NWP"),
+            st.Page(satellite_page, title="Satellite"),
+            st.Page(batch_page, title="Batch Visualisation Page"),
+        ],
+        "Cloudcasting": [
+            st.Page(cloudcasting_page, title="Cloudcasting"),
+        ],
+        "Legacy": [
+            st.Page(metric_page, title="Legacy Metrics"),
+            st.Page(forecast_page, title="Legacy Forecast"),
+            st.Page(adjuster_page, title="Legacy Adjuster"),
+        ]},
+        position="top",
+    )
     pg.run()


### PR DESCRIPTION
# Pull Request

## Description

Improves the UX on the dataplatform forecasts page. This is mostly done by preventing anything from being done until the user asks for it, reducing needless calls to the dataplatform.

Also groups items in the top bar since there are now so many.

https://github.com/user-attachments/assets/97792f1c-3855-4fb0-b709-b48d328e6f07


## How Has This Been Tested?

Running locally.

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
