### PR TITLE
feat: add Data Platform forecast page and enforce DataFrame schema in…

### DIFF
--- a/src/dataplatform/forecast/backend.py
+++ b/src/dataplatform/forecast/backend.py
@@ -166,7 +166,15 @@ async def fetch_observations(
     results = await asyncio.gather(*[fetch_one(obs, w) for obs in observers for w in time_windows])
     all_rows = [item for sublist in results for item in sublist]
 
-    df = pd.DataFrame(all_rows)
+    obs_columns = [
+        "target_timestamp_utc",
+        "value_fraction",
+        "effective_capacity_watts",
+        "observer_name",
+        "location_uuid",
+        "value_watts",
+    ]
+    df = pd.DataFrame(all_rows, columns=obs_columns) if all_rows else pd.DataFrame(columns=obs_columns)
 
     if not df.empty:
         df["target_timestamp_utc"] = pd.to_datetime(df["target_timestamp_utc"])

--- a/src/main_india.py
+++ b/src/main_india.py
@@ -15,6 +15,7 @@ from weather_forecast import weather_forecast_page
 from mlmodel import mlmodel_page
 from weather_graph import weather_graph_page
 from batch_page import batch_page
+from dataplatform.forecast.main import dp_forecast_page
 
 st.get_option("theme.primaryColor")
 st.set_page_config(layout="wide", page_title="OCF Dashboard")
@@ -24,18 +25,27 @@ def main_page():
 
 
 if check_password():
-    pg = st.navigation([
-        st.Page(main_page, title="🏠 Home", default=True),
-        st.Page(status_page, title="🚦 Status"),
-        st.Page(pvsite_forecast_page, title="📉 Site Forecast"),
-        st.Page(mlmodel_page, title="🤖 ML Models"),
-        st.Page(sites_toolbox_page, title="🛠️ Sites Toolbox"),
-        st.Page(user_page, title="👥 API Users"),
-        st.Page(nwp_page, title="🌤️ NWP"),
-        st.Page(satellite_page, title="🛰️ Satellite"),
-        st.Page(weather_forecast_page, title="🌦️ Weather Forecast"),
-        st.Page(weather_graph_page, title="🌨️ Weather Data"),
-        st.Page(batch_page, title="👀 Batch Visualisation Page"),
-    ], position="top")
+    pg = st.navigation({
+        "Home": [
+            st.Page(main_page, title="🏠 Home", default=True),
+            st.Page(status_page, title="🚦 Status"),
+            st.Page(user_page, title="👥 API Users"),
+        ],
+        "Data Platform": [
+            st.Page(dp_forecast_page, title="📊 DP Forecast"),
+        ],
+        "Sites": [
+            st.Page(pvsite_forecast_page, title="📉 Site Forecast"),
+            st.Page(mlmodel_page, title="🤖 ML Models"),
+            st.Page(sites_toolbox_page, title="🛠️ Sites Toolbox"),
+        ],
+        "Input Data": [
+            st.Page(nwp_page, title="🌤️ NWP"),
+            st.Page(satellite_page, title="🛰️ Satellite"),
+            st.Page(weather_forecast_page, title="🌦️ Weather Forecast"),
+            st.Page(weather_graph_page, title="🌨️ Weather Data"),
+            st.Page(batch_page, title="👀 Batch Visualisation Page"),
+        ],
+    }, position="top")
     pg.run()
 


### PR DESCRIPTION
# Pull Request

## Description

This PR introduces the Data Platform (DP) Forecast page to the India dashboard and improves the robustness of observation data processing in the backend.

**Key Changes:**
- **Navigation Refactor (`main_india.py`):** Reorganized the sidebar navigation into logical categories: "Home", "Data Platform", "Sites", and "Input Data".
- **Added DP Forecast Page:** Integrated the `dp_forecast_page` into the India dashboard.
- **Backend Schema Enforcement (`backend.py`):** Updated `fetch_observations` to explicitly define the column schema for the observations DataFrame. This ensures that essential columns like `observer_name` are always present, even if no data is returned, preventing `KeyError` crashes in the frontend plotting components.


## How Has This Been Tested?

- [x] Verified the new navigation structure in the India dashboard.
- [x] Confirmed the "DP Forecast" page loads and displays data correctly.
- [x] Tested the observation fetching logic with edge cases (empty data) to ensure no `KeyError` occurs.

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings

