### PR TITLE
fix(satellite_page): Correct function signature

### DIFF
--- a/src/satellite_page.py
+++ b/src/satellite_page.py
@@ -189,7 +189,7 @@ def satellite_page():
         df = df[["time", "variable", variable_name]]
 
         print("pivot on time")
-        df = df.pivot("time", columns="variable")
+        df = df.pivot(index="time", columns="variable")
         df.columns = [c[1] for c in df.columns]
 
         print("Making plot")


### PR DESCRIPTION
# Pull Request

## Description

The satellite time series method was returning a TypeError, which prevented the charts from rendering. This PR includes a fix for that issue.
<img width="2558" height="1008" alt="image" src="https://github.com/user-attachments/assets/adba3716-bf41-4765-9e4c-2336c6107046" />


## How Has This Been Tested?

tested by running locally


<img width="2560" height="1010" alt="Screenshot From 2026-05-18 15-11-14" src="https://github.com/user-attachments/assets/875001b4-aa43-4675-8f49-43ec30169237" />


## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
