### PR TITLE
chore(dp): Bump data platform version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ extra-index-url = ["https://pypi.org/simple"]
 
 [tool.uv.sources]
 
-dp-sdk = { url = "https://github.com/openclimatefix/data-platform/releases/download/v0.30.1/dp_sdk-0.30.1-py3-none-any.whl" }
+dp-sdk = { url = "https://github.com/openclimatefix/data-platform/releases/download/v0.31.1/dp_sdk-0.31.1-py3-none-any.whl" }
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py"]

--- a/src/dataplatform/forecast/backend.py
+++ b/src/dataplatform/forecast/backend.py
@@ -219,7 +219,7 @@ async def fetch_all_forecasts(
     req = messages_pb2.StreamForecastDataRequest(
         location_uuids=[location_uuid],
         energy_source=common_pb2.EnergySource.ENERGY_SOURCE_SOLAR,
-        time_window=messages_pb2.StreamForecastDataRequest.TimeWindow(
+        time_window=messages_pb2.TimeWindow(
             start_timestamp_utc=start_date, end_timestamp_utc=end_date
         ),
         forecasters=forecasters,

--- a/src/dataplatform/forecast/data.py
+++ b/src/dataplatform/forecast/data.py
@@ -82,7 +82,7 @@ async def get_forecast_data_one_forecaster(
         stream_forecast_data_request = messages_pb2.StreamForecastDataRequest(
             location_uuid=location.location_uuid,
             energy_source=common_pb2.EnergySource.ENERGY_SOURCE_SOLAR,
-            time_window=messages_pb2.StreamForecastDataRequest.TimeWindow(
+            time_window=messages_pb2.TimeWindow(
                 start_timestamp_utc=temp_start_date,
                 end_timestamp_utc=temp_end_date,
             ),


### PR DESCRIPTION
Bumps the data platform to 0.31.1 where the top-level Time Window object is used across all calls.